### PR TITLE
Prioritised demo css over src

### DIFF
--- a/component-structure/demo/index.html
+++ b/component-structure/demo/index.html
@@ -9,8 +9,8 @@
     <meta charset="UTF-8"/>
     <title>{{ component }}</title>
 
-    <link rel="stylesheet" href="css/demo.css"/>
     <link rel="stylesheet" href="css/{{ component }}.css"/>
+    <link rel="stylesheet" href="css/demo.css"/>
     <script type="text/javascript" src="js/{{ component }}.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Probably want to demo using component source all the time, but just in case someone wants to hack together a change but not include it in the `src/`, it makes sense anyway to have `demo/` styling override the `src/`.