### PR TITLE
Improves handling of AWS Credentials 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bower_components/
 npm-debug.log
 *.iml
 *.tgz
+.tern-port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  * Removed `html-concat` option
  * Removed the need to supply a git repo when running `component new`
  * Updated `component new` to `component new <<component-name>>`
+ * Added support for `~/.aws/credentials` for S3 releases. Default
+   config uses `pkg.name` as a profile in this file to get credentials.
 
 ## 0.9.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,20 @@ To build the Gulp Component Helper locally, you'll need to install:
 
 1. Fork the project
 2. Clone down your fork
-`git clone git://github.com/skyglobal/component-helper.git`
+`git clone git://github.com/YOUR_USER/component-helper.git`
 3. Setup your 'upstream'
 `git remote add upstream https://github.com/skyglobal/component-helper.git`
-4. Create a topic branch to contain your change
-`git checkout -b feature-my-feature`
-5. Make sure [CHANGELOG.md](./CHANGELOG.md) includes a summary of your changes in a new version number heading
-6. Make sure you are still up to date with master
+4. Run npm install `npm install`
+5. Create a topic branch to contain your change
+`git checkout -b my-feature`
+6. Hack, hack, hack
+7. Make sure [CHANGELOG.md](./CHANGELOG.md) includes a summary of your changes in a new version number heading
+8. Make sure you are still up to date with master
 `git pull upstream master`
-7. If necessary, rebase your commits into logical chunks, without errors.
-8. Push the branch up
-`git push origin my-awesome-feature`
-9. Create a pull request and describe what your change does and the why you think it should be merged.
+9. If necessary, rebase your commits into logical chunks, without errors.
+10. Push the branch up
+`git push origin my-feature`
+11. Create a pull request and describe what your change does and the why you think it should be merged.
 
 ## Running Locally
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing your Component
 
- > Only do this if you are ready for this to go public i.e. Is the repository address is never going to change
+ > Only do this if you are ready for this to go public i.e. the repository address is never going to change
 
 `component release`
 
@@ -19,6 +19,23 @@ To release to `bower` please update your `config/index.js` and run once :
 ### Amazon Web Services (AWS)
 
 To release to AWS please update your `component.config.js`.
+
+The recommended (and default) way to deal with AWS credentials is to
+use the standard file `~/.aws/credentials` with a dedicated section
+named after your component. This is achieved by the option `profile:
+pkg.name` in the release section of your `component.config.js`.
+
+If you don't have a `profile` setting in your `component.config.js`,
+then the default behaviour of the AWS SDK applies. This lets you use
+your default profile in `~/aws/credentials` or the standards
+environment variables **AWS_ACCESS_KEY_ID** and
+**AWS_SECRET_ACCESS_KEY** which take precedence over the file. For
+more information see
+[here](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs#).
+
+To specifically release to AWS, use `component release cloud`. That
+proves useful when you do a release but the AWS step fails due for
+instance to bad credentials.
 
 # Moving your component to SkyGlobal
 

--- a/component-structure/component.config.js
+++ b/component-structure/component.config.js
@@ -17,9 +17,8 @@ module.exports = {
     release: { // or false. add you release config here.
         type: 'aws',
         bucket: process.env.YOUR_AWS_BUCKET,
-        accessKey: process.env.YOUR_AWS_ACCESS_KEY_ID,
-        secret: process.env.YOUR_AWS_SECRET_ACCESS_KEY,
         region: process.env.YOUR_AWS_REGION,
+        profile: pkg.name // profile to be used in ~/.aws/credentials
         directoryPrefix: false //prefix your target release destination i.e. 'components/'
     },
     serve: {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimist": "^1.1.0",
     "mustache": "^1.0.0",
     "ncp": "^1.0.1",
-    "node-sass": "^2.0.0-beta",
+    "node-sass": "^2.0.1",
     "nodemon": "^1.3.6",
     "prompt": "^0.2.14",
     "replacestream": "^1.0.2",

--- a/spec/aws.spec.js
+++ b/spec/aws.spec.js
@@ -4,36 +4,36 @@ var AWSSDK   = require('aws-sdk');
 var log = require('../tasks/utils/log');
 
 function onError(e){
-    console.log('** Test Error **')
-    console.log(e)
-    expect(false).toBe(true)
+    console.log('** Test Error **');
+    console.log(e);
+    expect(false).toBe(true);
 }
 describe('AWS', function () {
 
-    var awsFileObj = {}
+    var awsFileObj = {};
 
     beforeEach(function(done){
         fs.read('./spec/fixtures/aws/aws.md').then(function(files){
             awsFileObj =  files[0];
         }).then(done);
-    })
+    });
 
     it('always saves destination with a single trailing slash', function () {
-        var aws = new AWS('src', 'dest', {})
-        expect(aws.destination).toBe('dest/')
-        var aws = new AWS('src', 'dest/', {})
-        expect(aws.destination).toBe('dest/')
+        var aws = new AWS('src', 'dest', {});
+        expect(aws.destination).toBe('dest/');
+        var aws = new AWS('src', 'dest/', {});
+        expect(aws.destination).toBe('dest/');
     });
 
     it('check the given key exists in the config object', function () {
         spyOn(log, 'onError');
-        var aws = new AWS('src', 'dest', {})
+        var aws = new AWS('src', 'dest', {});
         aws.checkMandatory('bill');
         expect(log.onError.calls.count()).toBe(1);
 
-        var aws = new AWS('src', 'dest', {bucket:'Bucket'})
-        aws.checkMandatory('ben')
-        aws.checkMandatory('Bucket')
+        var aws = new AWS('src', 'dest', {bucket:'Bucket'});
+        aws.checkMandatory('ben');
+        aws.checkMandatory('Bucket');
         expect(log.onError.calls.count()).toBe(2);
     });
 
@@ -77,10 +77,10 @@ describe('AWS', function () {
         });
         spyOn(AWS.prototype, 'setParams');
         spyOn(AWSSDK, 'S3').and.callFake(function (params){
-            expect(params.accessKeyId).toBe('access key')
-            expect(params.secretAccessKey).toBe('secret')
-            expect(params.region).toBe('region')
-            this.putObject = function(params, cb){cb()}
+            expect(params.accessKeyId).toBe('access key');
+            expect(params.secretAccessKey).toBe('secret');
+            expect(params.region).toBe('region');
+            this.putObject = function(params, cb){cb();};
         });
         aws.upload({}).then(function (msg) {
             expect(AWSSDK.S3.calls.count()).toBe(1);

--- a/spec/aws.spec.js
+++ b/spec/aws.spec.js
@@ -69,6 +69,12 @@ describe('AWS', function () {
     });
 
     it('should upload files to S3', function (done) {
+        spyOn(AWSSDK, 'S3').and.callFake(function (params){
+            expect(params.accessKeyId).toBe('access key');
+            expect(params.secretAccessKey).toBe('secret');
+            expect(AWSSDK.config.region).toBe('region');
+            this.putObject = function(params, cb){cb();};
+        });
         var aws = new AWS('./spec/fixtures/aws/aws.md', 'dest', {
             accessKey: 'access key',
             secret: 'secret',
@@ -76,16 +82,41 @@ describe('AWS', function () {
             bucket: 'Bucket'
         });
         spyOn(AWS.prototype, 'setParams');
-        spyOn(AWSSDK, 'S3').and.callFake(function (params){
-            expect(params.accessKeyId).toBe('access key');
-            expect(params.secretAccessKey).toBe('secret');
-            expect(params.region).toBe('region');
-            this.putObject = function(params, cb){cb();};
-        });
         aws.upload({}).then(function (msg) {
             expect(AWSSDK.S3.calls.count()).toBe(1);
             expect(AWS.prototype.setParams.calls.count()).toBe(1);
             expect(msg).toBe('S3::putObject "null" send');
         }).then(done).catch(onError);
+    });
+
+    it('should get credentials the standard way', function(done) {
+        process.env.AWS_ACCESS_KEY_ID = "env-id";
+        process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+
+        var aws = new AWS('./spec/fixtures/aws/aws.md', 'dest', {
+            region: 'region',
+            bucket: 'Bucket'
+        });
+
+        aws.s3.config.getCredentials(function() {done();});
+        // we can't check for "env-id" explicitly as if
+        // ~/.aws/credentials exists it takes precedence over
+        // process.env in this test. The point is the default SDK
+        // logic is enforced.
+        expect(aws.s3.config.credentials.accessKeyId).toBeDefined();
+
+    })
+    ;
+
+    it('should use the credential profile when provided one', function() {
+        // spyOn(AWSSDK.util, 'readFileSync').and.callThrough();
+        var aws = new AWS('./spec/fixtures/aws/aws.md', 'dest', {
+            region: 'region',
+            bucket: 'Bucket',
+            profile: 'profile'
+        });
+
+        expect(aws.s3.config.credentials.profile).toBe('profile');
+
     });
 });

--- a/tasks/wrappers/aws.js
+++ b/tasks/wrappers/aws.js
@@ -1,6 +1,6 @@
 var Promise = require('es6-promise').Promise;
-var AWSSDK   = require('aws-sdk');
-var mime  = require('mime');
+var AWSSDK = require('aws-sdk');
+var mime = require('mime');
 var log = require('../utils/log');
 var fs = require('../utils/fs');
 
@@ -18,18 +18,18 @@ function AWS(location, destination, options){
         Key    : null,
         Body   : null
     };
-}
+};
 
 AWS.prototype.addSlash = function(dir){
-    if (dir.slice(-1) !== '/') dir = dir +'/'
-    return dir
-}
+    if (dir.slice(-1) !== '/') dir = dir +'/';
+    return dir;
+};
 
 AWS.prototype.checkMandatory = function(key){
     if (!this.config[key] && !this.params[key]) {
         log.onError({message:'AWS: Missing config `' + key + '`'});
     }
-}
+};
 
 AWS.prototype.setParams = function(fileObj){
     this.checkMandatory('accessKey');
@@ -47,11 +47,11 @@ AWS.prototype.setParams = function(fileObj){
         .replace(fileObj.base, this.destination || '')
         .replace(new RegExp('\\\\', 'g'), '/');
     this.params.Body = fileObj.contents;
-}
+};
 
 AWS.prototype.upload = function(fileObj) {
     var self = this;
-    this.setParams(fileObj)
+    this.setParams(fileObj);
     return new Promise(function(resolve, reject){
         var s3 = new AWSSDK.S3({
             accessKeyId     : self.config.accessKey,
@@ -72,13 +72,13 @@ AWS.prototype.upload = function(fileObj) {
 AWS.prototype.write = function(){
     var self = this;
     return fs.read(this.location).then(function(files){
-        if (!files.length) log.info('No files found to release to AWS\n' + self.location)
-        var promises = []
+        if (!files.length) log.info('No files found to release to AWS\n' + self.location);
+        var promises = [];
         files.forEach(function(fileObj){
-            promises.push(self.upload(fileObj))
-        })
+            promises.push(self.upload(fileObj));
+        });
         return Promise.all(promises);
-    }).catch(log.onError)
-}
+    }).catch(log.onError);
+};
 
 module.exports = AWS;

--- a/tasks/wrappers/aws.js
+++ b/tasks/wrappers/aws.js
@@ -7,11 +7,22 @@ var fs = require('../utils/fs');
 function AWS(location, destination, options){
     this.location = location;
     this.destination = this.addSlash(destination);
-    this.config = {
-        accessKey: options.accessKey || process.env.AWS_ACCESS_KEY_ID || null,
-        secret: options.secret || process.env.AWS_SECRET_ACCESS_KEY || null,
-        region: options.region || process.env.AWS_REGION || null
-    };
+    AWSSDK.config.update({region: options.region || process.env.AWS_REGION || null});
+    var credentials;
+    if (options.profile) {
+        credentials = new AWSSDK.SharedIniFileCredentials({profile: options.profile});
+    }
+    var auth;
+    if (credentials) {
+        auth = { credentials: credentials };
+    } else if (options.accessKey && options.secret) {
+        auth = {
+            accessKeyId: options.accessKey,
+            secretAccessKey: options.secret
+        };
+    }
+    this.s3 = new AWSSDK.S3(auth);
+
     this.params = {
         Bucket : options.bucket || process.env.AWS_BUCKET || null,
         ACL    : options.acl || 'public-read',
@@ -26,15 +37,12 @@ AWS.prototype.addSlash = function(dir){
 };
 
 AWS.prototype.checkMandatory = function(key){
-    if (!this.config[key] && !this.params[key]) {
+    if (!this.params[key]) {
         log.onError({message:'AWS: Missing config `' + key + '`'});
     }
 };
 
 AWS.prototype.setParams = function(fileObj){
-    this.checkMandatory('accessKey');
-    this.checkMandatory('secret');
-    this.checkMandatory('region');
     this.checkMandatory('Bucket');
 
     if (fileObj.ext) {
@@ -53,13 +61,7 @@ AWS.prototype.upload = function(fileObj) {
     var self = this;
     this.setParams(fileObj);
     return new Promise(function(resolve, reject){
-        var s3 = new AWSSDK.S3({
-            accessKeyId     : self.config.accessKey,
-            secretAccessKey : self.config.secret,
-            region          : self.config.region
-        });
-
-        s3.putObject(self.params, function(err) {
+        self.s3.putObject(self.params, function(err) {
             if (err) {
                 reject({message: 'S3::putObject "' + self.params.Key + '" error!\n' + err});
             } else {


### PR DESCRIPTION
- support use of `~/.aws/credentials` for cloud release
- default `component.config.js` template to using profile `pkg.name` in `~/.aws/credentials`
- avoid logic to deal with env variables as SDK does it already.
- avoid S3 service recreation for each file uploaded.