### PR TITLE
improved test + coverage reporting

### DIFF
--- a/API.md
+++ b/API.md
@@ -121,9 +121,9 @@ Node Server example :
 
 This will do the above `serve`, but without the build step.
 
-#### Custom Path
+#### Adhoc
 
-`component serve your/path/to/serve`
+`component serve path/to/serve`
 
 This serve the path given as a static site
 

--- a/API.md
+++ b/API.md
@@ -121,6 +121,12 @@ Node Server example :
 
 This will do the above `serve`, but without the build step.
 
+#### Custom Path
+
+`component serve your/path/to/serve`
+
+This serve the path given as a static site
+
 ## Testing
 
 `component test`

--- a/API.md
+++ b/API.md
@@ -146,7 +146,7 @@ This will run your tests as mentioned above, but without the build step.
 
 `component test tdd`
 
-This will run through test and then stay open watching for code changes in your spec files.
+This will run through test and then stay open watching for code changes in your source code and your spec files.
 
 ## Init
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  * Updated cleaning to be less aggressive. This allows overlapping paths within `component.config.js`
  * Updated `karma.conf.js` to use browserify by default and to automatically apply shims
  * Removed dependency on Gulp for new components. Now recommended to use `component` commands.
+ * Added `component serve path/to/serve` option to allow a static path to be served instantly.
  * Added `jade` templating (for build.html config)
  * Added support for `~/.aws/credentials` for S3 releases
  * Added `clean` task in API/CLI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * Updated `component release cloud` to `component release s3` **breaking change**.
  * Updated `build`/`serve` to only warn of compilation problems rather than quiting.
  * Updated cleaning to be less aggressive. This allows overlapping paths within `component.config.js`
+ * Updated `karma.conf.js` to use browserify by default and to automatically apply shims
  * Removed dependency on Gulp for new components. Now recommended to use `component` commands.
  * Added `jade` templating (for build.html config)
  * Added support for `~/.aws/credentials` for S3 releases

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Component Helper [![NPM version](http://img.shields.io/npm/v/component-helper.svg)](https://www.npmjs.org/package/component-helper) [![Circle CI](https://circleci.com/gh/skyglobal/component-helper/tree/master.svg?style=svg)](https://circleci.com/gh/skyglobal/component-helper/tree/master)
 ========================
-> Quickly create new components or improve your existing build process
+> Quickly create new components or Improve your existing build process
 
-Out of the box you can:
  * Build and serve (static or NodeJS) sites
  * Automatic browser refresh when source code is changed
  * Use Jade or Mustache HTML templating
  * Compile Sass and CommonJS or AMD to CSS/JS and `.min` equivalents 
- * Test your code and keep an eye on code coverage
+ * Test your code and automatically retest on the fly with each code change. True TDD!
+ * Code coverage reporting by default with adjustable thresholds
  * Deploy to github.io, Bower and Amazon S3
  * Customise the build process using [component.config.js](component-structure/component.config.js) or using [gulp](component-structure/gulpfile.js).
 
@@ -20,9 +20,9 @@ Out of the box you can:
 1. Create a repository on github (optional)
 2. Run `component new *component-name*` (which will create your component directory)
 3. *follow on-screen instructions.*
-4. Run `component serve` in your component's directory.
-5. Run `component test` to test your code.
-6. Run `component release` to release your code.
+4. in your component's directory, Run `component serve` .
+5. Run `component test tdd` : test your code even while making code changes.
+6. Run `component release`  : release your code.
 
 ### Generated Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Component Helper [![NPM version](http://img.shields.io/npm/v/component-helper.sv
  * Test your code and automatically retest on the fly with each code change. True TDD!
  * Code coverage reporting by default with adjustable thresholds
  * Deploy to github.io, Bower and Amazon S3
- * Customise the build process using [component.config.js](component-structure/component.config.js) or using [gulp](component-structure/gulpfile.js).
+ * Customise the build process using [component.config.js](component-structure/component.config.js) or using [gulp](examples/gulpfile.js).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ CLI | Node
 [component build html](API.md/#html) | `component.build.html(replacements)` <br>(optional: replacements object)
 [component serve](API.md/#serve) | `component.serve.all(config)` <br>(optional: [server *config*](API.md#serve))
 [component serve quick](API.md/#quick) | `component.serve.quick(config)` <br>(optional: [server *config*](API.md#serve))
+[component serve path/to/serve](API.md/#adhoc) | `component.serve.adhoc(path)` <br>(mandatory: path/to/serve)
 [component test](API.md/#testing) | `component.test.all()`
 [component test quick](API.md/#quick-1) | `component.test.quick()`
 [component test tdd](API.md/#tdd) | `component.test.tdd()`

--- a/bin/component
+++ b/bin/component
@@ -10,18 +10,19 @@ var flags = minimist(process.argv.slice(2), knownArgs);
 function execTask(task, args){
     var helper = require("../");
     var command = args.shift() || 'all';
-    helper[task][command] && helper[task][command](args, flags.version).then(log.onSuccess, log.onError);
-    !helper[task][command] && help(helper[task], task);
+    helper[task][command] && helper[task][command](args, flags.version);
+    !helper[task][command] && helper[task]['adhoc'] && helper[task]['adhoc'](command);
+    !helper[task][command] && !helper[task]['adhoc'] && help(helper[task], task);
 }
 
 function help(task, taskStr){
     var args = [];
     for (var arg in task){
-        if (arg!=='all') args.push(arg)
+        if (arg!=='all' && arg!=='adhoc') args.push(arg);
     }
-    var helpStr = (taskStr === '') ? '' : '`component ' + taskStr + '` or '
+    var helpStr = (taskStr === '') ? '' : '`component ' + taskStr + '` or ';
     log.info([ taskStr + " arguments: " + args.join(', '),
-        "Usage: " + helpStr + "`component " + taskStr + " " + args[0] + "`"].join("\n"))
+        "Usage: " + helpStr + "`component " + taskStr + " " + args[0] + "`"].join("\n"));
 }
 
 var commands = {

--- a/component-structure/src/scripts/main.js
+++ b/component-structure/src/scripts/main.js
@@ -1,19 +1,17 @@
-// By default JS dependency is handled using browserify
-// please see 'GULP-TASKS.md#js' for more info
+// By default JS dependency is handled using CommonJS and browserify
+// please see 'API.md#scripts' for more info
 //
-// You may need another component:
-// run : $ bower install bskyb-core --save
-// then add
-// var core = require('../../bower_components/bskyb-core/src/scripts/core');
-// var event = core.event;
+// You may need other components. i.e. Run and uncomment the following :
+// $ bower install dependency-name --save
+// var dependency = require('../../bower_components/dependency-name/src/scripts/index');
 
 
 //example function
-function Test(){
+function Main(){
     this.version = require('./utils/version.js');//keep this : each component exposes its version
 }
 
-Test.prototype.sum = function(args){
+Main.prototype.sum = function(args){
     var total = 0;
     args.forEach(function(int){
         total += int;
@@ -23,9 +21,8 @@ Test.prototype.sum = function(args){
 
 
 //example export
-module.exports = Test;
+module.exports = Main;
 
 
-//keep this : ensure components are also globally available
-if (typeof skyComponents === "undefined") window.skyComponents = {};
-skyComponents['{{ component }}'] = module.exports;
+//Globals : if required
+//window['{{ component }}'] = module.exports;

--- a/component-structure/src/scripts/main.js
+++ b/component-structure/src/scripts/main.js
@@ -9,20 +9,21 @@
 
 
 //example function
-function sum(args){
+function Test(){
+    this.version = require('./utils/version.js');//keep this : each component exposes its version
+}
+
+Test.prototype.sum = function(args){
     var total = 0;
     args.forEach(function(int){
         total += int;
     });
     return total;
-}
+};
 
 
 //example export
-module.exports = {
-    sum: sum,
-    version: require('./utils/version.js')//keep this : each component exposes its version
-};
+module.exports = Test;
 
 
 //keep this : ensure components are also globally available

--- a/component-structure/test/helper.js
+++ b/component-structure/test/helper.js
@@ -1,0 +1,12 @@
+function loadAssets(){
+    document.body.innerHTML = __html__['_site/index.html'];
+    function appendCSS(fileObj){
+        var  link = document.createElement('link'); link.rel = 'stylesheet'; link.href='base/' + fileObj.path;  document.body.appendChild(link)
+    }
+    appendCSS({path: '_site/styles/demo.css'});
+    appendCSS({path: '_site/styles/{{ component }}.css'});
+}
+
+module.exports = {
+    loadAssets: loadAssets
+};

--- a/component-structure/test/karma.conf.js
+++ b/component-structure/test/karma.conf.js
@@ -1,16 +1,14 @@
 module.exports = function(config) {
-    return config.set({
+    var pkg = require('../package.json');
+    var karmaConfig = {
         basePath: '..',
         browsers: ['PhantomJS'],
-        frameworks: ['commonjs', 'jasmine'],
+        frameworks: ['browserify', 'jasmine'],
         reporters: ['progress', 'coverage'],
         preprocessors: {
-            'src/**/*.js': ['commonjs', 'coverage'],
-            'bower_components/bskyb-*/src/**/*.js': ['commonjs'],
-            'test/**/*.js': ['commonjs'],
+            'test/**/*.js': ['browserify'],
             '_site/*.html': ['html2js']
         },
-        plugins:['karma-html2js-preprocessor', 'karma-coverage', 'karma-commonjs', 'karma-jasmine', 'karma-phantomjs-launcher', 'karma-chrome-launcher'],
         coverageReporter: {
             dir : 'test/coverage/',
             reporters: [
@@ -28,15 +26,22 @@ module.exports = function(config) {
             ]
         },
         files: [
-            {pattern: '_site/*.html', watched: false },
-            {pattern: '_site/styles/*.*', included: true, served: true},
-            {pattern: 'bower_components/bskyb-*/src/**/*.js', included: true },
-            {pattern: '_site/**/*.*', included: false, served: true},
-            'src/**/*.js',
+            {pattern: '_site/**/*.*', included: true, served: true, watched: true},
             'test/**/*.spec.js'
         ],
         exclude: [
-            'src/**/*.requirejs.js'
+            '**/*.png',
+            '**/*.min.js',
+            '**/*.requirejs.js',
+            'bower_components/**/*',
+            'node_modules/**/*'
         ]
-    });
+    };
+    karmaConfig.browser = pkg.browser || {};
+    karmaConfig["browserify-shim"] = pkg["browserify-shim"] || {};
+    karmaConfig.browserify = pkg.browserify || {};
+    karmaConfig.browserify.transform = (karmaConfig.browserify.transform)
+        ? karmaConfig.browserify.transform.push('istanbulify')
+        : [ 'istanbulify' ];
+    return config.set(karmaConfig);
 };

--- a/component-structure/test/karma.conf.js
+++ b/component-structure/test/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
                         statements: [75, 85],
                         lines: [75, 85],
                         functions: [75, 85],
-                        branches:[50, 85]
+                        branches:[75, 85]
                     }},
                 { type: 'json-summary', subdir: '.', file: 'summary.json' },
             ]

--- a/component-structure/test/specs/main.spec.js
+++ b/component-structure/test/specs/main.spec.js
@@ -1,12 +1,27 @@
-document.body.innerHTML = __html__['_site/index.html'];
+/* Add Assets: HTML + CSS to setup page for functional testing */
+    document.body.innerHTML = __html__['_site/index.html'];
+    function appendCSS(fileObj){
+        var  link = document.createElement('link'); link.rel = 'stylesheet'; link.href='base/' + fileObj.path;  document.body.appendChild(link)
+    }
+    appendCSS({path: '_site/styles/demo.css'});
+    appendCSS({path: '_site/styles/{{ component }}.css'});
+/* End adding assets */
 
-var {{ component }} = skyComponents['{{ component }}'];
+/* Require file to test */
+var {{ component }} = require('../../src/scripts/{{ component }}');
 
+/* Start Test */
 describe('{{ component }} module can ', function () {
 
     it('sum an array of numbers', function () {
 
-        expect({{ component }}.sum([1,2,3])).toBe(6);
+        expect(new {{ component }}().sum([1,2,3])).toBe(6);
+
+    });
+
+    it('version is attached', function () {
+
+        expect(new {{ component }}().version).toBe('0.0.0');
 
     });
 

--- a/component-structure/test/specs/main.spec.js
+++ b/component-structure/test/specs/main.spec.js
@@ -1,14 +1,8 @@
-/* Add Assets: HTML + CSS to setup page for functional testing */
-    document.body.innerHTML = __html__['_site/index.html'];
-    function appendCSS(fileObj){
-        var  link = document.createElement('link'); link.rel = 'stylesheet'; link.href='base/' + fileObj.path;  document.body.appendChild(link)
-    }
-    appendCSS({path: '_site/styles/demo.css'});
-    appendCSS({path: '_site/styles/{{ component }}.css'});
-/* End adding assets */
+/* Add HTML + CSS to setup page for functional testing */
+require('../helper').loadAssets();
 
 /* Require file to test */
-var {{ component }} = require('../../src/scripts/{{ component }}');
+var {{ component }} = require('src/scripts/{{ component }}');
 
 /* Start Test */
 describe('{{ component }} module can ', function () {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "jade": "^1.9.2",
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.31",
+    "karma-browserify": "^4.0.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-commonjs": "0.0.13",
-    "karma-coverage": "^0.2.7",
+    "karma-coverage": "0.2.6",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jasmine": "^0.3.3",
     "karma-phantomjs-launcher": "^0.1.4",
@@ -61,6 +62,7 @@
   },
   "author": "Pete Mouland",
   "devDependencies": {
+    "istanbulify": "peter-mouland/istanbulify",
     "jasmine": "^2.1.1",
     "jshint": "^2.6.0"
   },

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -15,7 +15,7 @@ var now = Date().split(' ').splice(0,5).join(' ');
 
 helper.configCheck(component);
 
-function buildHtml(replacements) {
+function html(replacements) {
     replacements = (Array.isArray(replacements)) ? {} : replacements || {};
     if (!component.build.html){
         log.info('build.html set to false within component.config.js : skipping building html');
@@ -56,14 +56,14 @@ function images() {
     fs.copy(src, paths.site.images).catch(log.warn);
 }
 
-function buildScripts(options){
+function scripts(options){
     if (!component.build.scripts){
         log.info('build.scripts set to false within component.config.js : skipping building scripts');
         return Promise.resolve();
     }
     options = options || (component[component.build.scripts]) || {};
     return Promise.all([
-        new Scripts(paths.source.scripts, paths.dist.scripts, options).write(),
+        paths.dist && paths.dist.scripts && new Scripts(paths.source.scripts, paths.dist.scripts, options).write(),
         paths.demo && paths.demo.scripts && new Scripts(paths.demo.scripts, paths.site.scripts, options).write(),
         paths.site && paths.site.scripts && new Scripts(paths.source.scripts, paths.site.scripts, options).write()
     ]).then(function(){
@@ -78,7 +78,7 @@ function buildStyles(options){
     }
     options = options || (component[component.build.scripts]) || {};
     return Promise.all([
-        new Styles(paths.source.styles, paths.dist.styles, options).write(),
+        paths.dist && paths.dist.styles && new Styles(paths.source.styles, paths.dist.styles, options).write(),
         paths.site && paths.site.styles && new Styles(paths.source.styles, paths.site.styles, options).write(),
         paths.demo && paths.demo.styles && new Styles(paths.demo.styles, paths.site.styles, options).write()
     ]).then(function(){
@@ -91,11 +91,11 @@ function all(replacements){
     return clean.all().then(function(){
         log.info('Build All :');
         return Promise.all([
-                buildScripts(),
+                scripts(),
                 fonts(),
                 images(),
                 buildStyles(),
-                buildHtml(replacements)
+                html(replacements)
             ]);
     }).then(function(){
         return 'Build All Complete';
@@ -103,9 +103,9 @@ function all(replacements){
 }
 
 module.exports = {
-    html: buildHtml,
+    html: html,
     styles: buildStyles,
-    scripts: buildScripts,
+    scripts: scripts,
     images: images,
     fonts: fonts,
     all: all

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -12,9 +12,9 @@ var paths = helper.parsePaths(component.paths);
 
 helper.configCheck(component);
 
-function loadBrowser(options){
+function start(options){
     options = Array.isArray(options) && options.length>0 ? options[0] : (component[component.serve]) || {};
-    return startServer(options).then(function(){
+    return nodeApp(options).then(function(){
         if (!options.server && !options.proxy){
             log.warn('component.config.js may be incorrect. please check');
         }
@@ -22,9 +22,9 @@ function loadBrowser(options){
     });
 }
 
-function startServer(options){
-    if (!component.serve || component.serve === 'staticApp') return Promise.resolve();
+function nodeApp(options){
     return new Promise(function(resolve, reject){
+        if (!component.serve || component.serve === 'staticApp') resolve();
         nodemon(options).on('start', function(e){
             log.info('Server Started');
             resolve();
@@ -56,15 +56,26 @@ function watch(){
     fs.watch(imagesPaths,   [buildAndReload.images]);
 }
 
+function adhoc(path){
+    //todo: test if path ext is js or html
+    //    : if html serve staticApp
+    //    : if js serve nodeApp
+    component.serve = 'staticApp';
+    return start([{
+        server: { baseDir : path },
+        port: 3456
+    }]);
+}
 
 function quick(args){
-    return loadBrowser(args).then(function(){
+    return start(args).then(function(){
         watch();
     });
 }
 
 module.exports = {
     quick: quick,
+    adhoc: adhoc,
     all: function(args){
         return build.all().then(function(){
             return quick(args);

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -28,7 +28,11 @@ function quick(options){
     var test = new TestWrapper(options);
     return test.run(true).then(function(){
         return test.coverage();
-    }).catch(log.onError);
+    }).catch(function(message){
+        log.warn(['To view results please run',
+            ' * $ component serve test/coverage/phantomjs/'].join('\n'));
+        log.onError(message);
+    });
 }
 
 function all(options){


### PR DESCRIPTION
 * improve default test file comments/help
 * Use JS Class by default for `main.js`
 * browserify js within karma testing to allow browserify-shims etc
 * fix "karma-coverage": "0.2.6" to avoid bug/incompatiability in 0.2.7

@behaghel @robertmackenzie recommended update for sky-tags as this will allow full Jasmine testing plus code coverage and apply the sneaky browserify-shims automatically.