### PR TITLE
minifies html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
  * Speed improvements to the CLI
+ * Updated `build html` step to produce minified html
 
 ## 1.1.0  **breaking change**
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fs-extra": "^0.16.3",
     "gh-pages": "^0.2.0",
     "glob-stream": "^4.0.0",
+    "html-minifier": "^0.7.0",
     "jade": "^1.9.2",
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.31",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -30,8 +30,23 @@ function html(replacements) {
     replacements.site = {now: now, version:version, name: name};
     var src = [ paths.demo.root + '/*.{html,jade,mustache,ms}'];
     var htmlPromise = new Html(src, paths.site.root, replacements).write();
-    return htmlPromise.then(function(){
-            return 'Build HTML Complete';
+    return htmlPromise.then(function(fileObjs){
+        var promises = [];
+        fileObjs.forEach(function(fileObj){
+            fileObj.contents = minify(fileObj.contents, {
+                removeAttributeQuotes: true,
+                collapseBooleanAttributes : true,
+                collapseWhitespace: true,
+                useShortDoctype: true,
+                removeComments:true,
+                removeCommentsFromCdata:true,
+                removeEmptyAttributes: true
+            });
+            promises.push(fs.write(fileObj));
+        });
+        return Promise.all(promises);
+    }).then(function(){
+        return 'Build HTML Complete';
     }).catch(log.warn);
 }
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,4 +1,5 @@
 var Promise = require('es6-promise').Promise;
+var htmlMinify = require('html-minifier').minify;
 var findup = require('findup-sync');
 var log = require('./utils/log');
 var componentConfigPath = findup('component.config.js') || log.onError('You must have a component.config.js in the root of your project.');
@@ -33,7 +34,7 @@ function html(replacements) {
     return htmlPromise.then(function(fileObjs){
         var promises = [];
         fileObjs.forEach(function(fileObj){
-            fileObj.contents = minify(fileObj.contents, {
+            fileObj.contents = htmlMinify(fileObj.contents, {
                 removeAttributeQuotes: true,
                 collapseBooleanAttributes : true,
                 collapseWhitespace: true,


### PR DESCRIPTION
with the options:
```javascript
{
                removeAttributeQuotes: true,
                collapseBooleanAttributes : true,
                collapseWhitespace: true,
                useShortDoctype: true,
                removeComments:true,
                removeCommentsFromCdata:true,
                removeEmptyAttributes: true
            }
```

do we want a config option to turn it off?  i cant think why, i'm sure there might be an edge case with client side templating, just not sure where to put the config option? is the component.config.js file getting too big and complicated?

or shall we turn it on as it saves bytes, and worry about config as and when we need it, maybe never?