### PR TITLE
Reintroduce task command all for backward compat

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -127,5 +127,6 @@ module.exports = {
     scripts: scripts,
     images: images,
     fonts: fonts,
-    run: run
+    run: run,
+    all: run
 };

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -21,5 +21,6 @@ function run(type){
 
 module.exports = {
     run: run,
+    all: run,
     adhoc: run
 };

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -63,5 +63,6 @@ module.exports = {
     'gh-pages': ghPagesRelease,
     s3: s3,
     run: run,
+    all: run,
     adhoc: run
 };

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -74,5 +74,6 @@ function run(args){
 
 module.exports = {
     run: run,
+    all: run,
     adhoc: adhoc
 };

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -34,5 +34,6 @@ function run(options){
 
 module.exports = {
     tdd: tdd,
-    run: run
+    run: run,
+    all: run
 };


### PR DESCRIPTION
It has been inadvertently renamed `run()`. This fixes #87.

Not sure we want to test such a small change as part of the testing suite. I could test it on a broken project and it definitely fixed it.