### PR TITLE
more configurable release options

### DIFF
--- a/boilerplate/component.config.js
+++ b/boilerplate/component.config.js
@@ -11,7 +11,7 @@ module.exports = {
         scripts: 'browserify' // 'browserify' or 'requirejs'
     },
     test: 'karma', // or false. mocha not yet available.
-    release: 's3', // or false.
+    release: ['git', 'gh-pages', 's3'], // ['git', 'gh-pages','s3'] or false.
     serve: 'staticApp', // `staticApp` or `nodeApp`
     browserify: {
         insertGlobals : true,

--- a/boilerplate/component.config.js
+++ b/boilerplate/component.config.js
@@ -1,15 +1,7 @@
-var bower = require('./bower.json');
 var pkg = require('./package.json');
 
 module.exports = {
-    bower: bower,
-    build: {
-        fonts: true, // true or false. Set to false if you are doing your own thing in the fonts directory
-        images: true, // true or false.
-        styles: 'sass', // 'sass'. less not yet available
-        html: 'mustache',// 'mustache' or 'jade'. handlebars not yet available
-        scripts: 'browserify' // 'browserify' or 'requirejs'
-    },
+    build: ['fonts', 'images', 'sass', 'mustache', 'browserify'], //plus 'requirejs', 'jade'
     test: 'karma', // or false. mocha not yet available.
     release: ['git', 'gh-pages', 's3'], // ['git', 'gh-pages','s3'] or false.
     serve: 'staticApp', // `staticApp` or `nodeApp`

--- a/spec/build.spec.js
+++ b/spec/build.spec.js
@@ -7,11 +7,13 @@ var browserify = require('../tasks/wrappers/browserify');
 var Jade = require('../tasks/wrappers/jade');
 var Mustache = require('../tasks/wrappers/mustache');
 var sass = require('../tasks/wrappers/sass');
+var fs = require('../tasks/utils/fs');
 var htmlMinify = require('html-minifier');
 
 describe("Build task", function() {
 
     beforeEach(function(){
+        spyOn(fs,'copy').and.callFake(function(){ return Promise.resolve();});
         spyOn(log, "info").and.callFake(function(msg) { return msg; });
         spyOn(log, "onError").and.callFake(function(msg) { return msg; });
         spyOn(requirejs.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
@@ -79,6 +81,34 @@ describe("Build task", function() {
             });
         });
 
+        it("fonts", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.fonts().then(function(){
+                expect(fs.copy.calls.count()).toEqual(1);
+                expect(log.info).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("images", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.images().then(function(){
+                expect(fs.copy.calls.count()).toEqual(1);
+                expect(log.info).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("images when turned off", function (done) {
+            config.build.images = false;
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.images().then(function(){
+                expect(fs.copy.calls.count()).toEqual(0);
+                expect(log.info).toHaveBeenCalled();
+                done();
+            });
+        });
+
     });
 
     describe("will handle new style of build config for", function() {
@@ -127,6 +157,34 @@ describe("Build task", function() {
             build.styles().then(function(){
                 expect(sass.prototype.write.calls.count()).toEqual(1);
                 expect(log.info).toHaveBeenCalledWith('Build Styles Complete');
+                done();
+            });
+        });
+
+        it("fonts", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.fonts().then(function(){
+                expect(fs.copy.calls.count()).toEqual(1);
+                expect(log.info).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("images", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.images().then(function(){
+                expect(fs.copy.calls.count()).toEqual(1);
+                expect(log.info).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("images turned off", function (done) {
+            config.build[1] = false;
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.images().then(function(){
+                expect(fs.copy.calls.count()).toEqual(0);
+                expect(log.info).toHaveBeenCalled();
                 done();
             });
         });

--- a/spec/build.spec.js
+++ b/spec/build.spec.js
@@ -1,0 +1,137 @@
+var Promise = require('es6-promise').Promise;
+var build = require('../tasks/build');
+var helper = require('../tasks/utils/config-helper');
+var log = require('../tasks/utils/log');
+var requirejs = require('../tasks/wrappers/requirejs');
+var browserify = require('../tasks/wrappers/browserify');
+var Jade = require('../tasks/wrappers/jade');
+var Mustache = require('../tasks/wrappers/mustache');
+var sass = require('../tasks/wrappers/sass');
+var htmlMinify = require('html-minifier');
+
+describe("Build task", function() {
+
+    beforeEach(function(){
+        spyOn(log, "info").and.callFake(function(msg) { return msg; });
+        spyOn(log, "onError").and.callFake(function(msg) { return msg; });
+        spyOn(requirejs.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
+        spyOn(browserify.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
+        spyOn(sass.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
+        spyOn(Jade.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
+        spyOn(Mustache.prototype, "write").and.callFake(function(msg) { return Promise.resolve([]); });
+        spyOn(htmlMinify, "minify").and.callFake(function(msg) { return msg; });
+    });
+
+    describe("will handle old style of build config for", function() {
+
+        var config;
+        beforeEach(function() {
+            config = {
+                build: {
+                    fonts: true, // true or false. Set to false if you are doing your own thing in the fonts directory
+                    images: true, // true or false.
+                    styles: 'sass', // 'sass'. less not yet available
+                    html: 'mustache',// 'mustache' or 'jade'. handlebars not yet available
+                    scripts: 'browserify' // 'browserify' or 'requirejs'
+                }
+                , pkg: {version: '11.11.11'}, paths: {demo: {scripts: {}, styles: {}}, source: {}, site: {}}
+            };
+        });
+
+        it("html", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.html().then(function(){
+                expect(Mustache.prototype.write).toHaveBeenCalled();
+                expect(Jade.prototype.write).not.toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build HTML Complete');
+                done();
+            });
+        });
+
+        it("scripts with browserify", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.scripts().then(function(){
+                expect(browserify.prototype.write.calls.count()).toEqual(1);
+                expect(requirejs.prototype.write).not.toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build Scripts Complete');
+                done();
+            });
+        });
+
+
+        it("scripts with requirejs", function (done) {
+            config.build.scripts = 'requirejs';
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.scripts().then(function(){
+                expect(browserify.prototype.write.calls.count()).toEqual(0);
+                expect(requirejs.prototype.write).toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build Scripts Complete');
+                done();
+            });
+        });
+
+        it("styles", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.styles().then(function(){
+                expect(sass.prototype.write.calls.count()).toEqual(1);
+                expect(log.info).toHaveBeenCalledWith('Build Styles Complete');
+                done();
+            });
+        });
+
+    });
+
+    describe("will handle new style of build config for", function() {
+
+        var config;
+        beforeEach(function(){
+            config = {
+                build: ['fonts', 'images', 'sass', 'mustache', 'browserify']
+                ,pkg:{version:'11.11.11'}, paths:{demo:{scripts:{}, styles:{}},source:{},site:{}}
+            };
+        });
+
+        it("html", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.html().then(function(){
+                expect(Mustache.prototype.write).toHaveBeenCalled();
+                expect(Jade.prototype.write).not.toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build HTML Complete');
+                done();
+            });
+        });
+
+        it("scripts with browserify", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.scripts().then(function(){
+                expect(browserify.prototype.write.calls.count()).toEqual(1);
+                expect(requirejs.prototype.write).not.toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build Scripts Complete');
+                done();
+            });
+        });
+
+        it("scripts with requirejs", function (done) {
+            config.build[4] = 'requirejs';
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.scripts().then(function(){
+                expect(browserify.prototype.write.calls.count()).toEqual(0);
+                expect(requirejs.prototype.write).toHaveBeenCalled();
+                expect(log.info).toHaveBeenCalledWith('Build Scripts Complete');
+                done();
+            });
+        });
+
+        it("styles", function (done) {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            build.styles().then(function(){
+                expect(sass.prototype.write.calls.count()).toEqual(1);
+                expect(log.info).toHaveBeenCalledWith('Build Styles Complete');
+                done();
+            });
+        });
+
+
+    });
+
+});

--- a/spec/release.spec.js
+++ b/spec/release.spec.js
@@ -40,6 +40,12 @@ describe("Release", function() {
             expect(log.info).toHaveBeenCalled();
         });
 
+        it("old config", function () {
+            config.release = 's3';
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            expect(release.s3()).toBe('/11.11.11/');
+        });
+
     });
 
     describe("gh-pages", function() {

--- a/spec/release.spec.js
+++ b/spec/release.spec.js
@@ -1,31 +1,102 @@
 var Promise = require('es6-promise').Promise;
 var release = require('../tasks/release');
 var Release = require('../tasks/wrappers/s3');
+var git = require('../tasks/utils/git');
 var helper = require('../tasks/utils/config-helper');
+var ghPages = require('gh-pages');
 var log = require('../tasks/utils/log');
 
 describe("Release", function() {
 
+    beforeEach(function(){
+        spyOn(Release.prototype,'write').and.callFake(function(){ return this.destination; });
+        spyOn(log, "info").and.callFake(function(msg) { return msg; });
+        spyOn(ghPages, "publish").and.callFake(function(root, msg) { return msg; });
+        spyOn(git, "release").and.callFake(function(root, msg) { return msg; });
+        spyOn(log, "onError").and.callFake(function(msg) { return msg; });
+    });
+
     describe("s3", function() {
 
-        beforeEach(function(){
-            spyOn(Release.prototype,'write').and.callFake(function(){ return this.destination; });
-            spyOn(helper,'getConfig').and.callFake(function(){
-                return {
-                    build:{},release:'s3',pkg:{version:'11.11.11'}, paths:{source:{},site:{}},
-                    s3: { target: '/11.11.11/' }
-                };
-            });
-            spyOn(log, "info").and.callFake(function(msg) { return msg; });
-            spyOn(log, "onError").and.callFake(function(msg) { return msg; });
-        });
+        var config = {
+            build:{},release:['s3'],pkg:{version:'11.11.11'}, paths:{source:{},site:{}},
+            s3: { target: '/11.11.11/' }
+        };
 
         it("will set the target with the correct version", function () {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
             expect(release.s3()).toBe('/11.11.11/');
         });
 
         it("will update the target if the version has changed", function () {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
             expect(release.s3('11.12.11')).toBe('/11.12.11/');
+        });
+
+        it("will not release to s3 if not in config", function () {
+            delete config.release;
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            release.s3('11.12.11');
+            expect(log.info).toHaveBeenCalled();
+        });
+
+    });
+
+    describe("gh-pages", function() {
+
+        var config = {
+            build:{},release:['gh-pages'],pkg:{version:'11.11.11'}, paths:{source:{},site:{}},
+            s3: { target: '/11.11.11/' }
+        };
+
+        it("will publish to ghPages", function () {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            release['gh-pages']()
+            expect(ghPages.publish).toHaveBeenCalled();
+        });
+
+        it("will not release to gh-pages if not in config", function () {
+            delete config.release;
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            release['gh-pages']('v11.12.11');
+            expect(log.info).toHaveBeenCalled();
+            expect(ghPages.publish).not.toHaveBeenCalled();
+        });
+
+    });
+
+    describe("git", function() {
+
+        var config;
+        beforeEach(function() {
+            config = {
+                build: {}, release: ['git', 'gh-pages'], pkg: {version: '11.11.11'}, paths: {source: {}, site: {}},
+                s3: {target: '/11.11.11/'}
+            };
+        });
+
+        it("will release to git", function () {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            spyOn(git,'checkRemote').and.callFake(function(){ return true });
+            release.git()
+            expect(git.release).toHaveBeenCalled();
+        });
+
+        it("will not release to git if not in config", function () {
+            delete config.release;
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            spyOn(git,'checkRemote').and.callFake(function(){ return true });
+            release.git('v11.12.11');
+            expect(log.info).toHaveBeenCalled();
+            expect(git.release).not.toHaveBeenCalled();
+        });
+
+        it("will not release to git if no remote", function () {
+            spyOn(helper,'getConfig').and.callFake(function(){ return config; });
+            spyOn(git,'checkRemote').and.callFake(function(){ return false });
+            release.git('v11.12.11');
+            expect(log.onError).toHaveBeenCalled();
+            expect(git.release).not.toHaveBeenCalled();
         });
 
     });

--- a/spec/utils/config-helper.spec.js
+++ b/spec/utils/config-helper.spec.js
@@ -57,6 +57,7 @@ describe("Config-helper ", function() {
 
         beforeEach(function(){
             spyOn(log,'onError').and.callFake(function(){ return true;});
+            spyOn(log,'warn').and.callFake(function(){ return true;});
 
             completeConfig = {
                 build: {
@@ -75,10 +76,23 @@ describe("Config-helper ", function() {
             };
         });
 
-        it("knows when config is fine", function () {
+        it("knows when config is out of date", function () {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).not.toHaveBeenCalled();
+            expect(log.warn).toHaveBeenCalled();
+            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('release');
+            expect(isCompatible).toContain('build');
+        });
+
+        it("knows when config is as expected", function () {
+            completeConfig.build = [];
+            completeConfig.release = [];
+            spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
+            var isCompatible = helper.configCheck();
+            expect(log.onError).not.toHaveBeenCalled();
+            expect(log.warn).not.toHaveBeenCalled();
             expect(isCompatible).toBe(true);
         });
 
@@ -87,7 +101,7 @@ describe("Config-helper ", function() {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
-            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('be incorrect');
             expect(isCompatible).toContain('version');
         });
 
@@ -96,7 +110,7 @@ describe("Config-helper ", function() {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
-            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('be incorrect');
             expect(isCompatible).toContain(completeConfig.build.scripts);
         });
 
@@ -106,7 +120,7 @@ describe("Config-helper ", function() {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
-            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('be incorrect');
             expect(isCompatible).toContain(completeConfig.test);
         });
 
@@ -115,7 +129,7 @@ describe("Config-helper ", function() {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
-            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('be incorrect');
             expect(isCompatible).toContain(completeConfig.release);
         });
 
@@ -124,7 +138,7 @@ describe("Config-helper ", function() {
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
-            expect(isCompatible).toContain('be out of date');
+            expect(isCompatible).toContain('be incorrect');
             expect(isCompatible).toContain(completeConfig.serve);
         });
     })

--- a/spec/utils/config-helper.spec.js
+++ b/spec/utils/config-helper.spec.js
@@ -105,13 +105,14 @@ describe("Config-helper ", function() {
             expect(isCompatible).toContain('version');
         });
 
-        it("knows if the config is incorrect: missing browserify config", function () {
-            delete completeConfig.browserify;
+        it("knows if the config is incorrect: missing requirejs config", function () {
+            completeConfig.build= ['requirejs'];
+            delete completeConfig.requirejs;
             spyOn(helper,'getConfig').and.callFake(function(){ return completeConfig;});
             var isCompatible = helper.configCheck();
             expect(log.onError).toHaveBeenCalled();
             expect(isCompatible).toContain('be incorrect');
-            expect(isCompatible).toContain(completeConfig.build.scripts);
+            expect(isCompatible).toContain(completeConfig.build[0]);
         });
 
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -10,16 +10,32 @@ function initConfig(){
     pkg = component.pkg;
 }
 
+function matches(config, plugins){
+    //for backwards compatibility. deprecate in version 2
+    var compatibility = [];
+    if (config.fonts) compatibility.push('fonts');
+    if (config.images) compatibility.push('images');
+    if (config.styles) compatibility.push(config.styles);
+    if (config.html) compatibility.push(config.html);
+    if (config.scripts) compatibility.push(config.scripts);
+    if (compatibility.length) config = compatibility;
+
+    return config && config.map(function(i){
+        if (plugins.indexOf(i)>-1) return i;
+    }).join('');
+}
+
 var clean = require('./clean');
 
 function html(replacements) {
     initConfig();
-    replacements = replacements || {};
-    if (!component.build.html || !component.paths.demo){
-        log.info('build.html or paths.demo set to false within component.config.js : skipping building html');
+    var build = matches(component.build, ['jade','mustache']);
+    if (!build || !paths.demo){
+        log.info('Skipping build html');
         return Promise.resolve();
     }
-    var Html = require('./wrappers/' + (component.build.html || 'mustache'));
+    replacements = replacements || {};
+    var Html = require('./wrappers/' + build);
     var htmlMinify = require('html-minifier').minify;
 
     var now = Date().split(' ').splice(0,5).join(' ');
@@ -51,7 +67,7 @@ function html(replacements) {
 function fonts() {
     initConfig();
     if (!component.build.fonts) {
-        log.info('build.fonts within component.config.js is set to false : skipping copying fonts');
+        log.info('skipping build fonts');
         return Promise.resolve();
     }
     var location = [
@@ -64,7 +80,7 @@ function fonts() {
 function images() {
     initConfig();
     if (!paths.site) {
-        log.info('paths.site within component.config.js is missing : skipping copying images');
+        log.info('skipping build images');
         return Promise.resolve();
     }
     var src = paths.demo.images + '/**/*';
@@ -73,12 +89,13 @@ function images() {
 
 function scripts(options){
     initConfig();
-    if (!component.build.scripts){
-        log.info('build.scripts set to false within component.config.js : skipping building scripts');
+    var build = matches(component.build, ['browserify','requirejs']);
+    if (!build){
+        log.info('skipping build scripts');
         return Promise.resolve();
     }
-    var Scripts = require('./wrappers/' + (component.build.scripts || 'browserify'));
-    options = options || (component[component.build.scripts]) || {};
+    var Scripts = require('./wrappers/' + build);
+    options = options || component[build] || {};
     options.browserify = pkg.browserify;
     return Promise.all([
         paths.dist && paths.dist.scripts && new Scripts(paths.source.scripts, paths.dist.scripts, options).write(),
@@ -89,14 +106,15 @@ function scripts(options){
     }).catch(log.warn);
 }
 
-function buildStyles(options){
+function styles(options){
     initConfig();
-    if (!component.build.styles){
-        log.info('build.styles set to false within component.config.js : skipping building styles');
+    var build = matches(component.build, ['sass']);
+    if (!build){
+        log.info('Skipping build Sass');
         return Promise.resolve();
     }
-    var Styles = require('./wrappers/' + (component.build.styles || 'sass'));
-    options = options || (component[component.build.scripts]) || {};
+    var Styles = require('./wrappers/' + build);
+    options = options || (component[build]) || {};
     return Promise.all([
         paths.dist && paths.dist.styles && new Styles(paths.source.styles, paths.dist.styles, options).write(),
         paths.site && paths.site.styles && new Styles(paths.source.styles, paths.site.styles, options).write(),
@@ -113,7 +131,7 @@ function run(replacements){
                 scripts(),
                 fonts(),
                 images(),
-                buildStyles(),
+                styles(),
                 html(replacements)
             ]);
     }).then(function(){
@@ -123,7 +141,7 @@ function run(replacements){
 
 module.exports = {
     html: html,
-    styles: buildStyles,
+    styles: styles,
     scripts: scripts,
     images: images,
     fonts: fonts,

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -10,27 +10,12 @@ function initConfig(){
     pkg = component.pkg;
 }
 
-function matches(config, plugins){
-    //for backwards compatibility. deprecate in version 2
-    var compatibility = [];
-    if (config.fonts) compatibility.push('fonts');
-    if (config.images) compatibility.push('images');
-    if (config.styles) compatibility.push(config.styles);
-    if (config.html) compatibility.push(config.html);
-    if (config.scripts) compatibility.push(config.scripts);
-    if (compatibility.length) config = compatibility;
-
-    return config && config.map(function(i){
-        if (plugins.indexOf(i)>-1) return i;
-    }).join('');
-}
-
 var clean = require('./clean');
 
 function html(replacements) {
     initConfig();
-    var build = matches(component.build, ['jade','mustache']);
-    if (!build || !paths.demo){
+    var build = helper.matches(component.build, ['jade','mustache']);
+    if (!build || !paths.demo || !paths.site){
         log.info('Skipping build html');
         return Promise.resolve();
     }
@@ -66,30 +51,33 @@ function html(replacements) {
 
 function fonts() {
     initConfig();
-    if (!component.build.fonts) {
+    var build = helper.matches(component.build, ['fonts']);
+    if (!build || !paths.site) {
         log.info('skipping build fonts');
         return Promise.resolve();
     }
-    var location = [
-        paths.source.fonts + '/**/*',
-        paths.bower.fonts + '/**/*.{eot,ttf,woff,svg}'
-    ];
-    return fs.copy(location, paths.site.fonts).catch(log.warn);
+    var location = [];
+    paths.source && paths.source.fonts && location.push(paths.source.fonts + '/**/*.{eot,ttf,woff,svg}');
+    paths.bower && paths.bower.fonts && location.push(paths.bower.fonts + '/**/*.{eot,ttf,woff,svg}');
+    return fs.copy(location, paths.site.fonts);
 }
 
 function images() {
     initConfig();
-    if (!paths.site) {
+    var build = helper.matches(component.build, ['images']);
+    if (!build || !paths.site) {
         log.info('skipping build images');
         return Promise.resolve();
     }
-    var src = paths.demo.images + '/**/*';
-    fs.copy(src, paths.site.images).catch(log.warn);
+    var location = [];
+    paths.source && paths.source.images && location.push(paths.source.images + '/**/*');
+    paths.demo && paths.demo.images && location.push(paths.demo.images + '/**/*');
+    return fs.copy(location, paths.site.images);
 }
 
 function scripts(options){
     initConfig();
-    var build = matches(component.build, ['browserify','requirejs']);
+    var build = helper.matches(component.build, ['browserify','requirejs']);
     if (!build){
         log.info('skipping build scripts');
         return Promise.resolve();
@@ -108,7 +96,7 @@ function scripts(options){
 
 function styles(options){
     initConfig();
-    var build = matches(component.build, ['sass']);
+    var build = helper.matches(component.build, ['sass']);
     if (!build){
         log.info('Skipping build Sass');
         return Promise.resolve();

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -6,12 +6,14 @@ var component, paths, pkg;
 function run(type){
     component = helper.getConfig();
     if (type == 'current') return Promise.resolve(component.pkg.version);
-    log.info("\nBumping version : " + type );
+    log.info("\nBumping version");
     var build = require('./build');
     var Bump = require('./utils/bump');
     var newVersion;
     return new Bump(['./package.json','./README.md', component.paths.source.root + '/**/version.js'], {type: type }).run()
         .then(function(version){
+            log.info(" * Now on " + version);
+            log.info("Rebuilding HTML");
             newVersion = version;
             return build.html({version:version});
         }).then(function(){

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -37,7 +37,7 @@ function s3(version){
     }
     log.info("\nReleasing s3\n");
     var Release = require('./wrappers/s3');
-    var options = (component['s3']) || {};
+    var options = component.s3 || {};
     var target = options.target || options.directoryPrefix || '';//deprecate directoryPrefix
     if (version){
         target = target.replace(/("|\/)[0-9]+\.[0-9]+\.[0-9]\-?(?:(?:[0-9A-Za-z-]+\.?)+)?("|\/)/g, '$1' + version + '$2');

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -13,7 +13,7 @@ function getConfig(){
 
 function ghPagesRelease(message){
     getConfig();
-    if (component.release.indexOf('s3') <0){
+    if (!component.release || component.release.indexOf('gh-pages') <0){
         log.info('Skipping gh-pages Release');
         return Promise.resolve();
     }
@@ -31,7 +31,7 @@ function ghPagesRelease(message){
 
 function s3(version){
     getConfig();
-    if (component.release.indexOf('s3') <0){
+    if (!component.release || component.release.indexOf('s3') <0){
         log.info('Skipping S3 Release');
         return Promise.resolve();
     }
@@ -47,13 +47,13 @@ function s3(version){
 
 function releaseGit(version){
     getConfig();
-    if (component.release.indexOf('git') <0){
+    if (!component.release || component.release.indexOf('git') <0){
         log.info('Skipping Git Release');
         return Promise.resolve();
     }
     var git = require('./utils/git');
     if (!git.checkRemote()){
-        log.onError(['No valid Remote Git URL.',
+        return log.onError(['No valid Remote Git URL.',
             'Please update your `.git/config` file or run:',
             '$ component init git'].join('\n'));
     }

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,15 +1,25 @@
 var Promise = require('es6-promise').Promise;
 var log = require('./utils/log');
 var fs = require('./utils/fs');
-var git = require('./utils/git');
 var helper = require('./utils/config-helper');
 var component, paths, pkg;
 
-function ghPagesRelease(message){
-    var ghPages = require('gh-pages');
+function getConfig(){
     component = helper.getConfig();
+    component.release = (typeof component.release == 'string') ?
+        ['git', 'gh-pages', component.release] :
+        component.release;
+}
+
+function ghPagesRelease(message){
+    getConfig();
+    if (component.release.indexOf('s3') <0){
+        log.info('Skipping gh-pages Release');
+        return Promise.resolve();
+    }
+    var ghPages = require('gh-pages');
     message = message || 'Update';
-    log.info("\nReleasing to gh-pages : `" + message + "`\n");
+    log.info("\nReleasing to gh-pages\n");
     return new Promise(function(resolve, reject){
         ghPages.publish(component.paths.site.root, {message: message }, function(err) {
             ghPages.clean();
@@ -20,14 +30,14 @@ function ghPagesRelease(message){
 }
 
 function s3(version){
-    component = helper.getConfig();
-    if (!component.release){
-        log.info('Skipping Release : `Release` set to false within component.config.js');
+    getConfig();
+    if (component.release.indexOf('s3') <0){
+        log.info('Skipping S3 Release');
         return Promise.resolve();
     }
-    log.info("\nReleasing : \n");
-    var Release = require('./wrappers/' + (component.release || 's3'));
-    var options = (component[component.release]) || {};
+    log.info("\nReleasing s3\n");
+    var Release = require('./wrappers/s3');
+    var options = (component['s3']) || {};
     var target = options.target || options.directoryPrefix || '';//deprecate directoryPrefix
     if (version){
         target = target.replace(/("|\/)[0-9]+\.[0-9]+\.[0-9]\-?(?:(?:[0-9A-Za-z-]+\.?)+)?("|\/)/g, '$1' + version + '$2');
@@ -36,12 +46,19 @@ function s3(version){
 }
 
 function releaseGit(version){
-    if (!git.checkRemote()){
-        log.onError('No valid Remote Git URL.\nPlease update your `.git/config` file or run:\n $ component init git');
+    getConfig();
+    if (component.release.indexOf('git') <0){
+        log.info('Skipping Git Release');
+        return Promise.resolve();
     }
-    component = helper.getConfig();
+    var git = require('./utils/git');
+    if (!git.checkRemote()){
+        log.onError(['No valid Remote Git URL.',
+            'Please update your `.git/config` file or run:',
+            '$ component init git'].join('\n'));
+    }
     version = version || component.pkg.version;
-    log.info('Start release to Git : ' + version);
+    log.info('Releasing to Git');
     return git.release(version);
 }
 

--- a/tasks/utils/config-helper.js
+++ b/tasks/utils/config-helper.js
@@ -3,6 +3,20 @@ var findup = require('findup-sync');
 var config;
 
 var helper = {
+    matches: function matches(config, plugins){
+        //for backwards compatibility. deprecate in version 2
+        var compatibility = [];
+        if (config.fonts) compatibility.push('fonts');
+        if (config.images) compatibility.push('images');
+        if (config.styles) compatibility.push(config.styles);
+        if (config.html) compatibility.push(config.html);
+        if (config.scripts) compatibility.push(config.scripts);
+        if (compatibility.length) config = compatibility;
+
+        return config && config.map(function(i){
+                if (plugins.indexOf(i)>-1) return i;
+            }).join('');
+    },
     getConfig : function(){
         if (config) return config;
         var configPath = findup('component.config.js');
@@ -42,8 +56,8 @@ var helper = {
             warn.push(' * Please update `release` to be an array of items to be released.');
         }
         //check build config
-        if (config.build && config.build.scripts && !config[config.build.scripts]){
-            error.push(' * There is no build scripts config object: `' + config.build.scripts + ':{...}`');
+        if (config.build && config.build.indexOf && config.build.indexOf('requirejs')>=0 && !config.requirejs){
+            error.push(' * There is no scripts config object:  `requirejs:{...}`');
         }
         //check test config
         if (config.test && !config[config.test]){

--- a/tasks/utils/config-helper.js
+++ b/tasks/utils/config-helper.js
@@ -23,6 +23,9 @@ var helper = {
     configCheck : function(){
         var config = this.getConfig();
         var error = [
+            'Your `component.config.js` seems to be incorrect.'
+        ];
+        var warn = [
             'Your `component.config.js` seems to be out of date.'
         ];
         if (!config){
@@ -30,6 +33,13 @@ var helper = {
         }
         if (!config.pkg.version){
             error.push(' * The package.json requires as a `version` string (even "version": "0.0.0" is fine)');
+        }
+        //check old config
+        if (config.build && !Array.isArray(config.build)){
+            warn.push(' * Please update `build` to be an array of items to be built.');
+        }
+        if (config.release && !Array.isArray(config.release)){
+            warn.push(' * Please update `release` to be an array of items to be released.');
         }
         //check build config
         if (config.build && config.build.scripts && !config[config.build.scripts]){
@@ -53,6 +63,10 @@ var helper = {
         if (error.length>1){
             log.onError(error.join('\n'));
             return error.join('\n');
+        }
+        if (warn.length>1){
+            log.warn(warn.join('\n'));
+            return warn.join('\n');
         }
         return true;
     }

--- a/tasks/utils/config-helper.js
+++ b/tasks/utils/config-helper.js
@@ -22,37 +22,37 @@ var helper = {
     },
     configCheck : function(){
         var config = this.getConfig();
-        var message = [
+        var error = [
             'Your `component.config.js` seems to be out of date.'
         ];
         if (!config){
             log.onError('You must have a component.config.js in the root of your project.');
         }
         if (!config.pkg.version){
-            message.push(' * The package.json requires as a `version` string (even "version": "0.0.0" is fine)');
+            error.push(' * The package.json requires as a `version` string (even "version": "0.0.0" is fine)');
         }
         //check build config
         if (config.build && config.build.scripts && !config[config.build.scripts]){
-            message.push(' * There is no build scripts config object: `' + config.build.scripts + ':{...}`');
+            error.push(' * There is no build scripts config object: `' + config.build.scripts + ':{...}`');
         }
         //check test config
         if (config.test && !config[config.test]){
-            message.push(' * There is no test config object: `' + config.test + ': {...}`');
+            error.push(' * There is no test config object: `' + config.test + ': {...}`');
         }
 
         //check serve config
         if (config.serve && !config[config.serve]){
-            message.push(' * There is no server config object:  `' + config.serve + ':{...}`');
+            error.push(' * There is no server config object:  `' + config.serve + ':{...}`');
         }
 
         //check release config
-        if (config.release && !config[config.release]){
-            message.push(' * There is no release config object:  `' + config.release + ':{...}`');
+        if (config.release.indexOf('s3')>0 && !config.s3){
+            error.push(' * There is no release config object:  `s3:{...}`');
         }
 
-        if (message.length>1){
-            log.onError(message.join('\n'));
-            return message.join('\n');
+        if (error.length>1){
+            log.onError(error.join('\n'));
+            return error.join('\n');
         }
         return true;
     }

--- a/tasks/utils/config-helper.js
+++ b/tasks/utils/config-helper.js
@@ -46,7 +46,7 @@ var helper = {
         }
 
         //check release config
-        if (config.release.indexOf('s3')>0 && !config.s3){
+        if (config.release.indexOf('s3')>=0 && !config.s3){
             error.push(' * There is no release config object:  `s3:{...}`');
         }
 

--- a/tasks/utils/git.js
+++ b/tasks/utils/git.js
@@ -45,9 +45,7 @@ module.exports = {
     }()),
     release: function release(version){
         var git = this;
-        return git.add(['.']).then(function() {
-            return git.commit('v' + version);
-        }).then(function(){
+        return git.commit('v' + version).then(function() {
             return git.push(['origin', 'master']);
         }).then(function(){
             return git.tag('v' + version).catch(function(msg){


### PR DESCRIPTION
allow use to specify whether the release command should release to git, gh-pages and/or s3 using an array in the config  `release: ['git','gh-pages','s3']`

changes is backwards compatible.  if a string is found, it assumes you also want to release to git and gh-pages (i.e. same as pre v1.2).

fixes #78 