### PR TITLE
Add shrinkwrap to contributing/publish process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,7 @@ Any changes made to the component-helper will be picked up by the component. Use
 
  * Update [package.json](package.json) and [examples/package.json](examples/package.json) version number appropriately
  * `npm adduser` (first time only)
+ * `npm dedupe`
+ * `npm shrinkwrap`
  * `npm pack && tar -tf *.tgz && rm *.tgz` : Check the files in your package (especially index.js!)
  * `npm publish` : (needs npm v2.1.0+) https://www.npmjs.org/package/npm-release

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,7750 @@
+{
+  "name": "component-helper",
+  "version": "1.2.1",
+  "dependencies": {
+    "array-uniq": {
+      "version": "1.0.2",
+      "from": "array-uniq@1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+    },
+    "autoprefixer": {
+      "version": "5.1.0",
+      "from": "autoprefixer@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-5.1.0.tgz",
+      "dependencies": {
+        "autoprefixer-core": {
+          "version": "5.1.7",
+          "from": "autoprefixer-core@>=5.1.0 <5.2.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.7.tgz",
+          "dependencies": {
+            "browserslist": {
+              "version": "0.2.0",
+              "from": "browserslist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
+            },
+            "num2fraction": {
+              "version": "1.0.1",
+              "from": "num2fraction@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
+            },
+            "caniuse-db": {
+              "version": "1.0.30000081",
+              "from": "caniuse-db@>=1.0.30000078 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000081.tgz"
+            }
+          }
+        },
+        "postcss": {
+          "version": "4.0.6",
+          "from": "postcss@>=4.0.2 <4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.2.0",
+              "from": "source-map@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.7",
+              "from": "js-base64@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
+            }
+          }
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1.14",
+      "from": "aws-sdk@>=2.1.7 <3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.14.tgz",
+      "dependencies": {
+        "xml2js": {
+          "version": "0.2.6",
+          "from": "xml2js@0.2.6",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "0.4.2",
+              "from": "sax@0.4.2",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
+    "bower": {
+      "version": "1.3.12",
+      "from": "bower@>=1.3.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.5",
+          "from": "abbrev@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+        },
+        "archy": {
+          "version": "0.0.2",
+          "from": "archy@0.0.2",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+        },
+        "bower-config": {
+          "version": "0.5.2",
+          "from": "bower-config@>=0.5.2 <0.6.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "bower-json@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "intersect@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "bower-logger@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+        },
+        "bower-registry-client": {
+          "version": "0.2.3",
+          "from": "bower-registry-client@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.8 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "lru-cache@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@>=2.51.0 <2.52.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.9",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.7.0",
+                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "request-replay@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.0",
+          "from": "cardinal@0.4.0",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.5.0",
+          "from": "chalk@0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "chmodr@0.1.0",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+        },
+        "decompress-zip": {
+          "version": "0.0.8",
+          "from": "decompress-zip@0.0.8",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+          "dependencies": {
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+            },
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.2",
+              "from": "touch@0.0.2",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@>=1.0.10 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.8 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "2.2.1",
+              "from": "nopt@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.4",
+          "from": "fstream@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "fstream-ignore@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "4.0.6",
+          "from": "glob@>=4.0.2 <4.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.5",
+          "from": "graceful-fs@>=3.0.1 <3.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.7.1",
+          "from": "inquirer@0.7.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
+          "dependencies": {
+            "cli-color": {
+              "version": "0.3.2",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.6",
+                  "from": "es5-ext@>=0.10.2 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.2",
+                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "from": "es6-symbol@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx": {
+              "version": "2.4.1",
+              "from": "rx@>=2.2.27 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.4.3",
+          "from": "insight@0.4.3",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.1",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.2.0",
+                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.6.0",
+              "from": "inquirer@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
+              "dependencies": {
+                "cli-color": {
+                  "version": "0.3.2",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.6",
+                      "from": "es5-ext@>=0.10.2 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "memoizee": {
+                      "version": "0.3.8",
+                      "from": "memoizee@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                      "dependencies": {
+                        "es6-weak-map": {
+                          "version": "0.1.2",
+                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-symbol": {
+                              "version": "0.1.1",
+                              "from": "es6-symbol@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "event-emitter@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                        },
+                        "lru-queue": {
+                          "version": "0.1.0",
+                          "from": "lru-queue@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                        },
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    },
+                    "timers-ext": {
+                      "version": "0.1.0",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.4.1",
+                  "from": "rx@>=2.2.27 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.3.4 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "lodash.debounce": {
+              "version": "2.4.1",
+              "from": "lodash.debounce@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+              "dependencies": {
+                "lodash.isfunction": {
+                  "version": "2.4.1",
+                  "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.now": {
+                  "version": "2.4.1",
+                  "from": "lodash.now@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "1.0.0",
+              "from": "object-assign@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "os-name@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.0.0",
+                  "from": "osx-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz"
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "win-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.1 <0.13.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "is-root@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+        },
+        "junk": {
+          "version": "1.0.1",
+          "from": "junk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+        },
+        "lockfile": {
+          "version": "1.0.0",
+          "from": "lockfile@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
+        },
+        "lru-cache": {
+          "version": "2.5.0",
+          "from": "lru-cache@>=2.5.0 <2.6.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.9.1",
+          "from": "mout@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+        },
+        "nopt": {
+          "version": "3.0.1",
+          "from": "nopt@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+        },
+        "osenv": {
+          "version": "0.1.0",
+          "from": "osenv@0.1.0",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+        },
+        "p-throttler": {
+          "version": "0.1.0",
+          "from": "p-throttler@0.1.0",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@>=0.9.2 <0.10.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "promptly@0.2.0",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz"
+        },
+        "q": {
+          "version": "1.0.1",
+          "from": "q@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+        },
+        "request": {
+          "version": "2.42.0",
+          "from": "request@>=2.42.0 <2.43.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.6.0",
+              "from": "caseless@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.2",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.4.0",
+              "from": "oauth-sign@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.0",
+          "from": "request-progress@0.3.0",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.0",
+          "from": "retry@0.6.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+        },
+        "shell-quote": {
+          "version": "1.4.2",
+          "from": "shell-quote@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "array-filter@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "array-reduce@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "array-map@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.0",
+          "from": "stringify-object@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz"
+        },
+        "tar-fs": {
+          "version": "0.5.2",
+          "from": "tar-fs@0.5.2",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
+          "dependencies": {
+            "pump": {
+              "version": "0.3.5",
+              "from": "pump@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.2.0",
+                  "from": "once@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "0.4.7",
+              "from": "tar-stream@>=0.4.6 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.23",
+          "from": "tmp@0.0.23",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+        },
+        "update-notifier": {
+          "version": "0.2.0",
+          "from": "update-notifier@0.2.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
+          "dependencies": {
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.1",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.2.0",
+                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                }
+              }
+            },
+            "latest-version": {
+              "version": "0.2.0",
+              "from": "latest-version@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "0.2.0",
+                  "from": "package-json@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "0.3.0",
+                      "from": "got@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
+                      "dependencies": {
+                        "object-assign": {
+                          "version": "0.3.1",
+                          "from": "object-assign@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "0.1.1",
+                      "from": "registry-url@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
+                      "dependencies": {
+                        "npmconf": {
+                          "version": "2.1.1",
+                          "from": "npmconf@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+                          "dependencies": {
+                            "config-chain": {
+                              "version": "1.1.8",
+                              "from": "config-chain@>=1.1.8 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                              "dependencies": {
+                                "proto-list": {
+                                  "version": "1.2.3",
+                                  "from": "proto-list@>=1.2.1 <1.3.0",
+                                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "ini@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.1",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "uid-number": {
+                              "version": "0.0.5",
+                              "from": "uid-number@0.0.5",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "0.1.0",
+              "from": "semver-diff@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz"
+            },
+            "string-length": {
+              "version": "0.1.2",
+              "from": "string-length@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "0.2.2",
+                  "from": "strip-ansi@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.1.0",
+                      "from": "ansi-regex@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "browser-sync": {
+      "version": "2.2.1",
+      "from": "browser-sync@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.2.1.tgz",
+      "dependencies": {
+        "async-each-series": {
+          "version": "0.1.1",
+          "from": "async-each-series@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
+        },
+        "browser-sync-client": {
+          "version": "1.0.2",
+          "from": "browser-sync-client@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-1.0.2.tgz"
+        },
+        "browser-sync-ui": {
+          "version": "0.4.9",
+          "from": "browser-sync-ui@>=0.4.9 <0.5.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.4.9.tgz",
+          "dependencies": {
+            "angular": {
+              "version": "1.3.14",
+              "from": "angular@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.14.tgz"
+            },
+            "angular-route": {
+              "version": "1.3.14",
+              "from": "angular-route@>=1.3.8 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.3.14.tgz"
+            },
+            "angular-sanitize": {
+              "version": "1.3.14",
+              "from": "angular-sanitize@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.14.tgz"
+            },
+            "angular-touch": {
+              "version": "1.3.14",
+              "from": "angular-touch@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.3.14.tgz"
+            },
+            "connect-history-api-fallback": {
+              "version": "0.0.5",
+              "from": "connect-history-api-fallback@0.0.5",
+              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+            },
+            "weinre": {
+              "version": "2.0.0-pre-I0Z7U9OV",
+              "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
+              "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
+              "dependencies": {
+                "express": {
+                  "version": "2.5.11",
+                  "from": "express@>=2.5.0 <2.6.0",
+                  "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+                  "dependencies": {
+                    "connect": {
+                      "version": "1.9.2",
+                      "from": "connect@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+                      "dependencies": {
+                        "formidable": {
+                          "version": "1.0.17",
+                          "from": "formidable@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.4",
+                      "from": "mime@1.2.4",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+                    },
+                    "qs": {
+                      "version": "0.4.2",
+                      "from": "qs@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "connect": {
+          "version": "3.3.4",
+          "from": "connect@>=3.3.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.3.4.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.1.1",
+              "from": "debug@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.3.3",
+              "from": "finalhandler@0.3.3",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "on-finished": {
+                  "version": "2.2.0",
+                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "dev-ip": {
+          "version": "1.0.1",
+          "from": "dev-ip@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz"
+        },
+        "easy-extender": {
+          "version": "2.2.0",
+          "from": "easy-extender@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.2.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "eazy-logger": {
+          "version": "2.1.1",
+          "from": "eazy-logger@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-2.1.1.tgz",
+          "dependencies": {
+            "opt-merger": {
+              "version": "1.1.0",
+              "from": "opt-merger@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/opt-merger/-/opt-merger-1.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            },
+            "tfunk": {
+              "version": "3.0.1",
+              "from": "tfunk@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.0.1.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "object-path": {
+                  "version": "0.9.0",
+                  "from": "object-path@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "emitter-steward": {
+          "version": "0.0.1",
+          "from": "emitter-steward@>=0.0.1 <0.0.2",
+          "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-0.0.1.tgz"
+        },
+        "foxy": {
+          "version": "10.0.2",
+          "from": "foxy@>=10.0.2 <11.0.0",
+          "resolved": "https://registry.npmjs.org/foxy/-/foxy-10.0.2.tgz",
+          "dependencies": {
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "http-proxy": {
+              "version": "1.8.1",
+              "from": "http-proxy@>=1.8.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.1.tgz",
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "0.1.6",
+                  "from": "eventemitter3@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+                },
+                "requires-port": {
+                  "version": "0.0.0",
+                  "from": "requires-port@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+                }
+              }
+            },
+            "meow": {
+              "version": "2.1.0",
+              "from": "meow@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                        },
+                        "meow": {
+                          "version": "3.1.0",
+                          "from": "meow@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob-watcher": {
+          "version": "0.0.7",
+          "from": "glob-watcher@>=0.0.7 <0.0.8",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.7.tgz"
+        },
+        "immutable": {
+          "version": "3.6.2",
+          "from": "immutable@>=3.4.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.6.2.tgz"
+        },
+        "localtunnel": {
+          "version": "1.5.0",
+          "from": "localtunnel@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.5.0.tgz",
+          "dependencies": {
+            "request": {
+              "version": "2.11.4",
+              "from": "request@2.11.4",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.11.4.tgz",
+              "dependencies": {
+                "form-data": {
+                  "version": "0.0.3",
+                  "from": "form-data",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.3",
+                      "from": "combined-stream@0.0.3",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.1.9",
+                      "from": "async@0.1.9"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.7",
+                  "from": "mime"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.4",
+              "from": "optimist@0.3.4",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.3.1",
+          "from": "lodash@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz"
+        },
+        "meow": {
+          "version": "3.1.0",
+          "from": "meow@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.0.2",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.0",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.1",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.0",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            }
+          }
+        },
+        "portscanner": {
+          "version": "1.0.0",
+          "from": "portscanner@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+            }
+          }
+        },
+        "resp-modifier": {
+          "version": "2.0.1",
+          "from": "resp-modifier@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-2.0.1.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.6.2",
+          "from": "serve-index@>=1.6.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.2.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.4",
+              "from": "accepts@>=1.2.4 <1.3.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.5.1",
+                  "from": "negotiator@0.5.1",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.2",
+              "from": "batch@0.5.2",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+            },
+            "debug": {
+              "version": "2.1.1",
+              "from": "debug@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.0.9",
+              "from": "mime-types@>=2.0.9 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.7.0",
+                  "from": "mime-db@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.9.1",
+          "from": "serve-static@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.1.tgz",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "send": {
+              "version": "0.12.1",
+              "from": "send@0.12.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.12.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "2.1.1",
+                  "from": "debug@>=2.1.1 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "depd": {
+                  "version": "1.0.0",
+                  "from": "depd@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+                },
+                "destroy": {
+                  "version": "1.0.3",
+                  "from": "destroy@1.0.3",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                },
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@>=1.5.1 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                },
+                "fresh": {
+                  "version": "0.2.4",
+                  "from": "fresh@0.2.4",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                },
+                "on-finished": {
+                  "version": "2.2.0",
+                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "1.0.2",
+                  "from": "range-parser@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "socket.io": {
+          "version": "1.3.4",
+          "from": "socket.io@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.4.tgz",
+          "dependencies": {
+            "engine.io": {
+              "version": "1.5.1",
+              "from": "engine.io@1.5.1",
+              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.3",
+                  "from": "debug@1.0.3",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "ws": {
+                  "version": "0.5.0",
+                  "from": "ws@0.5.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.4.3",
+                      "from": "nan@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    },
+                    "ultron": {
+                      "version": "1.0.1",
+                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                    }
+                  }
+                },
+                "base64id": {
+                  "version": "0.1.0",
+                  "from": "base64id@0.1.0",
+                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.3",
+              "from": "socket.io-parser@2.2.3",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.3.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "benchmark@1.0.0",
+                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                }
+              }
+            },
+            "socket.io-client": {
+              "version": "1.3.4",
+              "from": "socket.io-client@1.3.4",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.4.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "engine.io-client": {
+                  "version": "1.5.1",
+                  "from": "engine.io-client@1.5.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
+                  "dependencies": {
+                    "has-cors": {
+                      "version": "1.0.3",
+                      "from": "has-cors@1.0.3",
+                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                      "dependencies": {
+                        "global": {
+                          "version": "2.0.1",
+                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.4.31",
+                      "from": "ws@0.4.31",
+                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "0.6.1",
+                          "from": "commander@>=0.6.1 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                        },
+                        "nan": {
+                          "version": "0.3.2",
+                          "from": "nan@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                        },
+                        "tinycolor": {
+                          "version": "0.0.1",
+                          "from": "tinycolor@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                        },
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        }
+                      }
+                    },
+                    "xmlhttprequest": {
+                      "version": "1.5.0",
+                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+                      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                    },
+                    "debug": {
+                      "version": "1.0.4",
+                      "from": "debug@1.0.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "parseuri": {
+                      "version": "0.0.4",
+                      "from": "parseuri@0.0.4",
+                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parsejson": {
+                      "version": "0.0.1",
+                      "from": "parsejson@0.0.1",
+                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
+                    },
+                    "parseqs": {
+                      "version": "0.0.2",
+                      "from": "parseqs@0.0.2",
+                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
+                    },
+                    "component-inherit": {
+                      "version": "0.0.3",
+                      "from": "component-inherit@0.0.3",
+                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                    },
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@1.0.2",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "component-bind@1.0.0",
+                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "object-component@0.0.3",
+                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                },
+                "has-binary": {
+                  "version": "0.1.6",
+                  "from": "has-binary@0.1.6",
+                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "parseuri": {
+                  "version": "0.0.2",
+                  "from": "parseuri@0.0.2",
+                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-array": {
+                  "version": "0.1.3",
+                  "from": "to-array@0.1.3",
+                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                },
+                "backo2": {
+                  "version": "1.0.2",
+                  "from": "backo2@1.0.2",
+                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "from": "socket.io-adapter@0.3.1",
+              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "from": "debug@1.0.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "from": "socket.io-parser@2.2.2",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "benchmark@1.0.0",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    }
+                  }
+                },
+                "object-keys": {
+                  "version": "1.0.1",
+                  "from": "object-keys@1.0.1",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                }
+              }
+            },
+            "has-binary-data": {
+              "version": "0.1.3",
+              "from": "has-binary-data@0.1.3",
+              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz"
+            },
+            "debug": {
+              "version": "2.1.0",
+              "from": "debug@2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "engine.io-parser": {
+              "version": "1.2.1",
+              "from": "engine.io-parser@1.2.1",
+              "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+              "dependencies": {
+                "after": {
+                  "version": "0.8.1",
+                  "from": "after@0.8.1",
+                  "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                },
+                "arraybuffer.slice": {
+                  "version": "0.0.6",
+                  "from": "arraybuffer.slice@0.0.6",
+                  "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                },
+                "base64-arraybuffer": {
+                  "version": "0.1.2",
+                  "from": "base64-arraybuffer@0.1.2",
+                  "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                },
+                "blob": {
+                  "version": "0.0.2",
+                  "from": "blob@0.0.2",
+                  "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                },
+                "has-binary": {
+                  "version": "0.1.5",
+                  "from": "has-binary@0.1.5",
+                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "utf8": {
+                  "version": "2.0.0",
+                  "from": "utf8@2.0.0",
+                  "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.3",
+          "from": "ua-parser-js@>=0.7.3 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.3.tgz"
+        }
+      }
+    },
+    "browserify": {
+      "version": "9.0.3",
+      "from": "browserify@>=9.0.3 <10.0.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.10.0",
+          "from": "JSONStream@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "0.0.5",
+              "from": "jsonparse@0.0.5",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@>=2.2.7 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            }
+          }
+        },
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browser-pack": {
+          "version": "4.0.0",
+          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.0.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "umd": {
+              "version": "3.0.0",
+              "from": "umd@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
+            }
+          }
+        },
+        "browser-resolve": {
+          "version": "1.7.2",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.5",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.0.3",
+          "from": "buffer@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "from": "base64-js@0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.4",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+            },
+            "is-array": {
+              "version": "1.0.1",
+              "from": "is-array@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+            }
+          }
+        },
+        "builtins": {
+          "version": "0.0.7",
+          "from": "builtins@>=0.0.3 <0.1.0",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+        },
+        "commondir": {
+          "version": "0.0.1",
+          "from": "commondir@0.0.1",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+        },
+        "concat-stream": {
+          "version": "1.4.7",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "dependencies": {
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.9.13",
+          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "dependencies": {
+            "browserify-aes": {
+              "version": "1.0.0",
+              "from": "browserify-aes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+            },
+            "browserify-sign": {
+              "version": "2.8.0",
+              "from": "browserify-sign@2.8.0",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "dependencies": {
+                "browserify-rsa": {
+                  "version": "1.1.1",
+                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                },
+                "parse-asn1": {
+                  "version": "2.0.0",
+                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "1.0.3",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "asn1.js-rfc3280": {
+                      "version": "1.0.0",
+                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
+                    },
+                    "pemstrip": {
+                      "version": "0.0.1",
+                      "from": "pemstrip@0.0.1",
+                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-ecdh": {
+              "version": "2.0.0",
+              "from": "create-ecdh@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz"
+            },
+            "create-hash": {
+              "version": "1.1.0",
+              "from": "create-hash@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+              "dependencies": {
+                "ripemd160": {
+                  "version": "1.0.0",
+                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                }
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.3",
+              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+            },
+            "diffie-hellman": {
+              "version": "3.0.1",
+              "from": "diffie-hellman@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "dependencies": {
+                "miller-rabin": {
+                  "version": "1.1.5",
+                  "from": "miller-rabin@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz"
+                }
+              }
+            },
+            "pbkdf2-compat": {
+              "version": "3.0.2",
+              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+            },
+            "public-encrypt": {
+              "version": "2.0.0",
+              "from": "public-encrypt@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "dependencies": {
+                "browserify-rsa": {
+                  "version": "2.0.0",
+                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                },
+                "parse-asn1": {
+                  "version": "3.0.0",
+                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "1.0.3",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "randombytes": {
+              "version": "2.0.1",
+              "from": "randombytes@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
+            },
+            "bn.js": {
+              "version": "1.3.0",
+              "from": "bn.js@1.3.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+            },
+            "brorand": {
+              "version": "1.0.5",
+              "from": "brorand@1.0.5",
+              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+            },
+            "elliptic": {
+              "version": "1.0.1",
+              "from": "elliptic@1.0.1",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+              "dependencies": {
+                "hash.js": {
+                  "version": "1.0.2",
+                  "from": "hash.js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.0",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+        },
+        "defined": {
+          "version": "0.0.0",
+          "from": "defined@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+        },
+        "deps-sort": {
+          "version": "1.3.5",
+          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.4",
+          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "events": {
+          "version": "1.0.2",
+          "from": "events@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "4.4.1",
+          "from": "glob@>=4.0.5 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.0",
+          "from": "has@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "dependencies": {
+            "Base64": {
+              "version": "0.2.1",
+              "from": "Base64@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+        },
+        "insert-module-globals": {
+          "version": "6.2.0",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.7.4",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                }
+              }
+            },
+            "lexical-scope": {
+              "version": "1.1.0",
+              "from": "lexical-scope@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "dependencies": {
+                "astw": {
+                  "version": "1.1.0",
+                  "from": "astw@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "3001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "process": {
+              "version": "0.6.0",
+              "from": "process@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+            }
+          }
+        },
+        "labeled-stream-splicer": {
+          "version": "1.0.2",
+          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "dependencies": {
+            "stream-splicer": {
+              "version": "1.3.1",
+              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "dependencies": {
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "module-deps": {
+          "version": "3.7.2",
+          "from": "module-deps@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.7.4",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "detective": {
+              "version": "4.0.0",
+              "from": "detective@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                },
+                "escodegen": {
+                  "version": "1.6.1",
+                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.1",
+                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.4",
+                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
+                    },
+                    "optionator": {
+                      "version": "0.5.0",
+                      "from": "optionator@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "dependencies": {
+                        "prelude-ls": {
+                          "version": "1.1.1",
+                          "from": "prelude-ls@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "from": "deep-is@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "type-check@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "levn": {
+                          "version": "0.2.5",
+                          "from": "levn@>=0.2.5 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.0.6",
+                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "subarg": {
+              "version": "0.0.1",
+              "from": "subarg@0.0.1",
+              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.2",
+              "from": "through2@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "parents": {
+          "version": "1.0.1",
+          "from": "parents@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "dependencies": {
+            "path-platform": {
+              "version": "0.11.15",
+              "from": "path-platform@>=0.11.15 <0.12.0",
+              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+            }
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.10.0",
+          "from": "process@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+        },
+        "punycode": {
+          "version": "1.2.4",
+          "from": "punycode@>=1.2.3 <1.3.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.5",
+          "from": "resolve@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+        },
+        "shallow-copy": {
+          "version": "0.0.1",
+          "from": "shallow-copy@0.0.1",
+          "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+        },
+        "shasum": {
+          "version": "1.0.1",
+          "from": "shasum@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "0.0.1",
+              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shell-quote": {
+          "version": "0.0.1",
+          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "from": "subarg@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
+        },
+        "syntax-error": {
+          "version": "1.1.2",
+          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.9.0",
+              "from": "acorn@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.0",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "url": {
+          "version": "0.10.2",
+          "from": "url@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "from": "indexof@0.0.1",
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+        },
+        "sha.js": {
+          "version": "2.3.6",
+          "from": "sha.js@2.3.6",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+        },
+        "combine-source-map": {
+          "version": "0.3.0",
+          "from": "combine-source-map@0.3.0",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+          "dependencies": {
+            "inline-source-map": {
+              "version": "0.3.1",
+              "from": "inline-source-map@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.3.0",
+                  "from": "source-map@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.31 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "chalk": {
+      "version": "1.0.0",
+      "from": "chalk@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.0.1",
+          "from": "ansi-styles@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "has-ansi": {
+          "version": "1.0.3",
+          "from": "has-ansi@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.3.0",
+          "from": "supports-color@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.0.tgz"
+        }
+      }
+    },
+    "chokidar": {
+      "version": "1.0.0-rc3",
+      "from": "chokidar@>=1.0.0-rc2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc3.tgz",
+      "dependencies": {
+        "anymatch": {
+          "version": "1.1.0",
+          "from": "anymatch@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.1.0.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "async-each": {
+          "version": "0.1.6",
+          "from": "async-each@>=0.1.5 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+        },
+        "glob-parent": {
+          "version": "1.0.0",
+          "from": "glob-parent@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.0.0.tgz",
+          "dependencies": {
+            "is-glob": {
+              "version": "0.3.0",
+              "from": "is-glob@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-0.3.0.tgz"
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.0",
+          "from": "is-binary-path@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+          "dependencies": {
+            "binary-extensions": {
+              "version": "1.3.0",
+              "from": "binary-extensions@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+            }
+          }
+        },
+        "readdirp": {
+          "version": "1.3.0",
+          "from": "readdirp@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.12 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26-2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "0.3.5",
+          "from": "fsevents@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.5.3",
+              "from": "nan@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "colors": {
+      "version": "1.0.3",
+      "from": "colors@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+    },
+    "convert-source-map": {
+      "version": "0.3.5",
+      "from": "convert-source-map@0.3.5",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+    },
+    "dateformat": {
+      "version": "1.0.11",
+      "from": "dateformat@1.0.11",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+      "dependencies": {
+        "meow": {
+          "version": "3.1.0",
+          "from": "meow@*",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.0.2",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.0",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.1",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "dependencies": {
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.0",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.2.11",
+      "from": "deep-extend@0.2.11",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+    },
+    "del": {
+      "version": "1.1.1",
+      "from": "del@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
+      "dependencies": {
+        "each-async": {
+          "version": "1.1.1",
+          "from": "each-async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "dependencies": {
+            "onetime": {
+              "version": "1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+            },
+            "set-immediate-shim": {
+              "version": "1.0.0",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
+            }
+          }
+        },
+        "globby": {
+          "version": "1.2.0",
+          "from": "globby@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "dependencies": {
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "glob": {
+              "version": "4.4.1",
+              "from": "glob@>=4.4.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "from": "is-path-cwd@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+          "dependencies": {
+            "is-path-inside": {
+              "version": "1.0.0",
+              "from": "is-path-inside@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+              "dependencies": {
+                "path-is-inside": {
+                  "version": "1.0.1",
+                  "from": "path-is-inside@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        }
+      }
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "from": "duplexer2@0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.0.0",
+      "from": "end-of-stream@1.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+      "dependencies": {
+        "once": {
+          "version": "1.3.1",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "es6-promise": {
+      "version": "2.0.1",
+      "from": "es6-promise@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz"
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "from": "esprima@1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+    },
+    "findup-sync": {
+      "version": "0.2.1",
+      "from": "findup-sync@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.0 <4.4.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fs-extra": {
+      "version": "0.16.3",
+      "from": "fs-extra@>=0.16.3 <0.17.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.3.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.5",
+          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+        },
+        "jsonfile": {
+          "version": "2.0.0",
+          "from": "jsonfile@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+        }
+      }
+    },
+    "gaze": {
+      "version": "0.5.1",
+      "from": "gaze@0.5.1",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+      "dependencies": {
+        "globule": {
+          "version": "0.1.0",
+          "from": "globule@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+            },
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@>=3.1.21 <3.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "from": "get-stdin@4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "gh-pages": {
+      "version": "0.2.0",
+      "from": "gh-pages@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.2.0.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.0.1",
+          "from": "q@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+        },
+        "q-io": {
+          "version": "1.11.6",
+          "from": "q-io@>=1.11.0 <1.12.0",
+          "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            },
+            "url2": {
+              "version": "0.0.0",
+              "from": "url2@>=0.0.0 <0.0.1",
+              "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
+            },
+            "mimeparse": {
+              "version": "0.1.4",
+              "from": "mimeparse@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
+            },
+            "collections": {
+              "version": "0.2.2",
+              "from": "collections@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+              "dependencies": {
+                "weak-map": {
+                  "version": "1.0.0",
+                  "from": "weak-map@1.0.0",
+                  "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.1",
+          "from": "graceful-fs@2.0.1",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz"
+        },
+        "async": {
+          "version": "0.2.9",
+          "from": "async@0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+        },
+        "wrench": {
+          "version": "1.5.1",
+          "from": "wrench@1.5.1",
+          "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.1.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "glob": {
+          "version": "4.0.6",
+          "from": "glob@>=4.0.2 <4.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "glob-stream": {
+      "version": "4.0.1",
+      "from": "glob-stream@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.0.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "4.4.1",
+          "from": "glob@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.1",
+          "from": "minimatch@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ordered-read-streams": {
+          "version": "0.1.0",
+          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+        },
+        "glob2base": {
+          "version": "0.0.12",
+          "from": "glob2base@>=0.0.12 <0.0.13",
+          "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+          "dependencies": {
+            "find-index": {
+              "version": "0.1.1",
+              "from": "find-index@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+            }
+          }
+        },
+        "unique-stream": {
+          "version": "2.0.2",
+          "from": "unique-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+          "dependencies": {
+            "es6-set": {
+              "version": "0.1.1",
+              "from": "es6-set@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.6",
+                  "from": "es5-ext@>=0.10.4 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "from": "es6-symbol@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.3",
+                  "from": "event-emitter@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                }
+              }
+            },
+            "through2-filter": {
+              "version": "1.4.1",
+              "from": "through2-filter@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "html-minifier": {
+      "version": "0.7.0",
+      "from": "html-minifier@*",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.0.tgz",
+      "dependencies": {
+        "change-case": {
+          "version": "2.2.0",
+          "from": "change-case@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.2.0.tgz",
+          "dependencies": {
+            "camel-case": {
+              "version": "1.1.1",
+              "from": "camel-case@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
+            },
+            "constant-case": {
+              "version": "1.1.0",
+              "from": "constant-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
+            },
+            "dot-case": {
+              "version": "1.1.1",
+              "from": "dot-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
+            },
+            "is-lower-case": {
+              "version": "1.1.1",
+              "from": "is-lower-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
+            },
+            "is-upper-case": {
+              "version": "1.1.1",
+              "from": "is-upper-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
+            },
+            "lower-case": {
+              "version": "1.1.2",
+              "from": "lower-case@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
+            },
+            "param-case": {
+              "version": "1.1.1",
+              "from": "param-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
+            },
+            "pascal-case": {
+              "version": "1.1.0",
+              "from": "pascal-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
+            },
+            "path-case": {
+              "version": "1.1.1",
+              "from": "path-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
+            },
+            "sentence-case": {
+              "version": "1.1.2",
+              "from": "sentence-case@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
+            },
+            "snake-case": {
+              "version": "1.1.1",
+              "from": "snake-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
+            },
+            "swap-case": {
+              "version": "1.1.0",
+              "from": "swap-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
+            },
+            "title-case": {
+              "version": "1.1.0",
+              "from": "title-case@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
+            },
+            "upper-case": {
+              "version": "1.1.2",
+              "from": "upper-case@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
+            },
+            "upper-case-first": {
+              "version": "1.1.0",
+              "from": "upper-case-first@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.0.tgz"
+            }
+          }
+        },
+        "clean-css": {
+          "version": "3.0.10",
+          "from": "clean-css@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.10.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.5.1",
+              "from": "commander@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.43 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "cli": {
+          "version": "0.6.5",
+          "from": "cli@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.1 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@0.1.2",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.6",
+          "from": "relateurl@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+        }
+      }
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "jade": {
+      "version": "1.9.2",
+      "from": "jade@>=1.9.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
+      "dependencies": {
+        "character-parser": {
+          "version": "1.2.1",
+          "from": "character-parser@1.2.1",
+          "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
+        },
+        "commander": {
+          "version": "2.6.0",
+          "from": "commander@>=2.6.0 <2.7.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+        },
+        "constantinople": {
+          "version": "3.0.1",
+          "from": "constantinople@>=3.0.1 <3.1.0",
+          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "transformers": {
+          "version": "2.1.0",
+          "from": "transformers@2.1.0",
+          "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+          "dependencies": {
+            "promise": {
+              "version": "2.0.0",
+              "from": "promise@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "dependencies": {
+                "is-promise": {
+                  "version": "1.0.1",
+                  "from": "is-promise@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
+                }
+              }
+            },
+            "css": {
+              "version": "1.0.8",
+              "from": "css@>=1.0.8 <1.1.0",
+              "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.0.4",
+                  "from": "css-parse@1.0.4",
+                  "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
+                },
+                "css-stringify": {
+                  "version": "1.0.5",
+                  "from": "css-stringify@1.0.5",
+                  "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.2.5",
+              "from": "uglify-js@>=2.2.5 <2.3.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "void-elements": {
+          "version": "2.0.1",
+          "from": "void-elements@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+        },
+        "with": {
+          "version": "4.0.1",
+          "from": "with@>=4.0.0 <4.1.0",
+          "resolved": "https://registry.npmjs.org/with/-/with-4.0.1.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.11.0",
+              "from": "acorn@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+            }
+          }
+        },
+        "acorn-globals": {
+          "version": "1.0.2",
+          "from": "acorn-globals@1.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.11.0",
+              "from": "acorn@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "jasmine-core": {
+      "version": "2.2.0",
+      "from": "jasmine-core@>=2.1.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz"
+    },
+    "karma": {
+      "version": "0.12.31",
+      "from": "karma@>=0.12.31 <0.13.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
+      "dependencies": {
+        "di": {
+          "version": "0.0.1",
+          "from": "di@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "from": "socket.io@0.9.16",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "dependencies": {
+            "socket.io-client": {
+              "version": "0.9.16",
+              "from": "socket.io-client@0.9.16",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "from": "uglify-js@1.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                },
+                "ws": {
+                  "version": "0.4.32",
+                  "from": "ws@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.1.0",
+                      "from": "commander@>=2.1.0 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                    },
+                    "nan": {
+                      "version": "1.0.0",
+                      "from": "nan@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "xmlhttprequest@1.4.2",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                },
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "from": "active-x-obfuscator@0.0.1",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "from": "zeparser@0.0.5",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "from": "policyfile@0.0.4",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "from": "redis@0.7.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "0.12.6",
+          "from": "chokidar@>=0.8.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+          "dependencies": {
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "readdirp@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "fsevents": {
+              "version": "0.3.5",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.5.3",
+                  "from": "nan@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@>=3.2.7 <3.3.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "0.10.4",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@*",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "i": {
+                  "version": "0.3.2",
+                  "from": "i@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@>=0.9.7 <0.10.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@>=2.4.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "log4js": {
+          "version": "0.6.22",
+          "from": "log4js@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.22.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@>=1.1.4 <1.2.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.10",
+          "from": "useragent@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "from": "graceful-fs@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+        },
+        "connect": {
+          "version": "2.26.6",
+          "from": "connect@>=2.26.0 <2.27.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.8.4",
+              "from": "body-parser@>=1.8.4 <1.9.0",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@0.4.4",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "from": "raw-body@1.3.0",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.3.4",
+              "from": "cookie-parser@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.4.tgz",
+              "dependencies": {
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "from": "cookie-signature@1.0.6",
+                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                }
+              }
+            },
+            "cookie-signature": {
+              "version": "1.0.5",
+              "from": "cookie-signature@1.0.5",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+            },
+            "compression": {
+              "version": "1.1.2",
+              "from": "compression@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
+              "dependencies": {
+                "compressible": {
+                  "version": "2.0.2",
+                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.3.0",
+              "from": "connect-timeout@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz"
+            },
+            "csurf": {
+              "version": "1.6.6",
+              "from": "csurf@>=1.6.2 <1.7.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
+              "dependencies": {
+                "csrf": {
+                  "version": "2.0.6",
+                  "from": "csrf@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.6.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    },
+                    "rndm": {
+                      "version": "1.1.0",
+                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0",
+                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                    },
+                    "uid-safe": {
+                      "version": "1.1.0",
+                      "from": "uid-safe@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.1.2",
+                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-errors": {
+                  "version": "1.2.8",
+                  "from": "http-errors@>=1.2.8 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+            },
+            "errorhandler": {
+              "version": "1.2.4",
+              "from": "errorhandler@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "express-session": {
+              "version": "1.8.2",
+              "from": "express-session@>=1.8.2 <1.9.0",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.0.0",
+                  "from": "crc@3.0.0",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                },
+                "uid-safe": {
+                  "version": "1.0.1",
+                  "from": "uid-safe@1.0.1",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "dependencies": {
+                    "mz": {
+                      "version": "1.3.0",
+                      "from": "mz@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.2.0",
+                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+                        },
+                        "thenify": {
+                          "version": "3.1.0",
+                          "from": "thenify@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
+                        },
+                        "thenify-all": {
+                          "version": "1.6.0",
+                          "from": "thenify-all@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+                        }
+                      }
+                    },
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.2.0",
+              "from": "finalhandler@0.2.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+            },
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "method-override": {
+              "version": "2.2.0",
+              "from": "method-override@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.0",
+                  "from": "methods@1.1.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.3.2",
+              "from": "morgan@>=1.3.2 <1.4.0",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.0",
+                  "from": "basic-auth@1.0.0",
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                }
+              }
+            },
+            "multiparty": {
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.0",
+              "from": "on-headers@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "qs": {
+              "version": "2.2.4",
+              "from": "qs@2.2.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
+            },
+            "response-time": {
+              "version": "2.0.1",
+              "from": "response-time@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.1.7",
+              "from": "serve-favicon@>=2.1.5 <2.2.0",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
+              "dependencies": {
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.2.1",
+              "from": "serve-index@>=1.2.1 <1.3.0",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.9",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.7.0",
+                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.1",
+                  "from": "batch@0.5.1",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.6.5",
+              "from": "serve-static@>=1.6.4 <1.7.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.9.3",
+                  "from": "send@0.9.3",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.3",
+                      "from": "destroy@1.0.3",
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                    },
+                    "etag": {
+                      "version": "1.4.0",
+                      "from": "etag@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
+                      "dependencies": {
+                        "crc": {
+                          "version": "3.0.0",
+                          "from": "crc@3.0.0",
+                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.1.0",
+                      "from": "on-finished@2.1.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.0.5",
+                          "from": "ee-first@1.0.5",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.5.7",
+              "from": "type-is@>=1.5.2 <1.6.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.9",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vhost": {
+              "version": "3.0.0",
+              "from": "vhost@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            },
+            "vary": {
+              "version": "1.0.0",
+              "from": "vary@1.0.0",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.0.5",
+                  "from": "ee-first@1.0.5",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                }
+              }
+            },
+            "accepts": {
+              "version": "1.1.4",
+              "from": "accepts@1.1.4",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@>=2.0.4 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.4.9",
+                  "from": "negotiator@0.4.9",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.31 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-browserify": {
+      "version": "4.0.0",
+      "from": "karma-browserify@*",
+      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.0.0.tgz",
+      "dependencies": {
+        "hat": {
+          "version": "0.0.3",
+          "from": "hat@0.0.3",
+          "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz"
+        },
+        "js-string-escape": {
+          "version": "1.0.0",
+          "from": "js-string-escape@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "from": "minimatch@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "os-shim": {
+          "version": "0.1.2",
+          "from": "os-shim@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz"
+        },
+        "watchify": {
+          "version": "2.4.0",
+          "from": "watchify@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.4.0.tgz",
+          "dependencies": {
+            "chokidar": {
+              "version": "0.12.6",
+              "from": "chokidar@>=0.12.1 <0.13.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+              "dependencies": {
+                "readdirp": {
+                  "version": "1.3.0",
+                  "from": "readdirp@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.12 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "fsevents": {
+                  "version": "0.3.5",
+                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.5.3",
+                      "from": "nan@>=1.5.0 <1.6.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.7",
+      "from": "karma-chrome-launcher@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz"
+    },
+    "karma-coverage": {
+      "version": "0.2.6",
+      "from": "karma-coverage@0.2.6",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.2.6.tgz",
+      "dependencies": {
+        "istanbul": {
+          "version": "0.3.7",
+          "from": "istanbul@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.7.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "2.0.0",
+              "from": "esprima@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.3.3",
+              "from": "escodegen@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.0.0",
+                  "from": "esutils@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.1.1",
+                  "from": "esprima@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.33 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "1.3.0",
+              "from": "handlebars@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "from": "supports-color@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "from": "resolve@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.1",
+                  "from": "argparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.2.0",
+                      "from": "lodash@>=3.2.0 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ibrik": {
+          "version": "1.1.1",
+          "from": "ibrik@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/ibrik/-/ibrik-1.1.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "coffee-script-redux": {
+              "version": "2.0.0-beta8",
+              "from": "coffee-script-redux@2.0.0-beta8",
+              "resolved": "https://registry.npmjs.org/coffee-script-redux/-/coffee-script-redux-2.0.0-beta8.tgz",
+              "dependencies": {
+                "StringScanner": {
+                  "version": "0.0.3",
+                  "from": "StringScanner@>=0.0.3 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz"
+                },
+                "nopt": {
+                  "version": "2.1.2",
+                  "from": "nopt@>=2.1.2 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "esmangle": {
+                  "version": "0.0.17",
+                  "from": "esmangle@>=0.0.8 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
+                  "dependencies": {
+                    "escope": {
+                      "version": "1.0.1",
+                      "from": "escope@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.1.tgz"
+                    },
+                    "estraverse": {
+                      "version": "1.3.2",
+                      "from": "estraverse@>=1.3.2 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
+                    },
+                    "esshorten": {
+                      "version": "0.0.2",
+                      "from": "esshorten@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
+                      "dependencies": {
+                        "estraverse": {
+                          "version": "1.2.0",
+                          "from": "estraverse@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.11",
+                  "from": "source-map@0.1.11",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.11.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "escodegen": {
+                  "version": "0.0.28",
+                  "from": "escodegen@>=0.0.24 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    },
+                    "estraverse": {
+                      "version": "1.3.2",
+                      "from": "estraverse@>=1.3.2 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
+                    }
+                  }
+                },
+                "cscodegen": {
+                  "version": "0.1.0",
+                  "from": "../../../../../var/folders/nz/csl3swp54vd9ntllwqlhjc_w0000gn/T/npm-10855-49f3bd29/1425556562936-0.1502521219663322/73fd7202ac086c26f18c9d56f025b18b3c6f5383",
+                  "resolved": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383"
+                }
+              }
+            },
+            "istanbul": {
+              "version": "0.2.16",
+              "from": "istanbul@>=0.2.4 <0.3.0",
+              "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "escodegen": {
+                  "version": "1.3.3",
+                  "from": "escodegen@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "1.0.0",
+                      "from": "esutils@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.1.1",
+                      "from": "esprima@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.33 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "handlebars": {
+                  "version": "1.3.0",
+                  "from": "handlebars@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+                  "dependencies": {
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                    },
+                    "uglify-js": {
+                      "version": "2.3.6",
+                      "from": "uglify-js@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@>=0.2.6 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.1.43",
+                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+                },
+                "fileset": {
+                  "version": "0.1.5",
+                  "from": "fileset@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                },
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "resolve": {
+                  "version": "0.7.4",
+                  "from": "resolve@>=0.7.0 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+                },
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.1",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.2.0",
+                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "estraverse": {
+              "version": "1.5.1",
+              "from": "estraverse@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+            },
+            "escodegen": {
+              "version": "1.1.0",
+              "from": "escodegen@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                },
+                "esutils": {
+                  "version": "1.0.0",
+                  "from": "esutils@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.30 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-html2js-preprocessor": {
+      "version": "0.1.0",
+      "from": "karma-html2js-preprocessor@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
+    },
+    "karma-jasmine": {
+      "version": "0.3.5",
+      "from": "karma-jasmine@>=0.3.3 <0.4.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.1.4",
+      "from": "karma-phantomjs-launcher@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
+      "dependencies": {
+        "phantomjs": {
+          "version": "1.9.15",
+          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+            },
+            "kew": {
+              "version": "0.4.0",
+              "from": "kew@0.4.0",
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+            },
+            "npmconf": {
+              "version": "2.0.9",
+              "from": "npmconf@2.0.9",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.8",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.3",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@1.1.8",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+            },
+            "request": {
+              "version": "2.42.0",
+              "from": "request@2.42.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@0.3.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@>=1.2.11 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+    },
+    "minimist": {
+      "version": "1.1.0",
+      "from": "minimist@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+    },
+    "mustache": {
+      "version": "1.1.0",
+      "from": "mustache@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "from": "ncp@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+    },
+    "node-sass": {
+      "version": "2.0.1",
+      "from": "node-sass@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "0.2.6",
+          "from": "cross-spawn@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            }
+          }
+        },
+        "meow": {
+          "version": "3.1.0",
+          "from": "meow@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.0.2",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.0",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.1",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "dependencies": {
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.0",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "mocha": {
+          "version": "2.1.0",
+          "from": "mocha@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.3.0",
+              "from": "commander@2.3.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@2.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.0.8",
+              "from": "diff@1.0.8",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "from": "escape-string-regexp@1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "glob": {
+              "version": "3.2.3",
+              "from": "glob@3.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "growl": {
+              "version": "1.8.1",
+              "from": "growl@1.8.1",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+            },
+            "jade": {
+              "version": "0.26.3",
+              "from": "jade@0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "mkdirp@0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "nan": {
+          "version": "1.6.2",
+          "from": "nan@>=1.6.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+        },
+        "npmconf": {
+          "version": "2.1.1",
+          "from": "npmconf@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@>=1.1.8 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.3",
+              "from": "ini@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.5",
+              "from": "uid-number@0.0.5",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "request@>=2.53.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.9",
+              "from": "mime-types@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.7.0",
+                  "from": "mime-db@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.2",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "hawk@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.11.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+                },
+                "boom": {
+                  "version": "2.6.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+            }
+          }
+        },
+        "sass-graph": {
+          "version": "1.0.3",
+          "from": "sass-graph@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.6.0",
+              "from": "commander@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+            },
+            "glob": {
+              "version": "4.4.1",
+              "from": "glob@>=4.3.4 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "nodemon": {
+      "version": "1.3.7",
+      "from": "nodemon@>=1.3.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.7.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "ps-tree": {
+          "version": "0.0.3",
+          "from": "ps-tree@>=0.0.3 <0.1.0",
+          "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
+          "dependencies": {
+            "event-stream": {
+              "version": "0.5.3",
+              "from": "event-stream@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.2.8",
+                  "from": "optimist@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "touch": {
+          "version": "0.0.3",
+          "from": "touch@>=0.0.3 <0.1.0",
+          "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+          "dependencies": {
+            "nopt": {
+              "version": "1.0.10",
+              "from": "nopt@>=1.0.10 <1.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "update-notifier": {
+          "version": "0.3.1",
+          "from": "update-notifier@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
+          "dependencies": {
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.5",
+                  "from": "graceful-fs@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                },
+                "js-yaml": {
+                  "version": "3.2.7",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.1",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.2.0",
+                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.0.0",
+                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                },
+                "osenv": {
+                  "version": "0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "from": "is-npm@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+            },
+            "latest-version": {
+              "version": "1.0.0",
+              "from": "latest-version@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "1.1.0",
+                  "from": "package-json@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "2.4.0",
+                      "from": "got@>=2.4.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
+                      "dependencies": {
+                        "duplexify": {
+                          "version": "3.2.0",
+                          "from": "duplexify@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "infinity-agent": {
+                          "version": "1.0.2",
+                          "from": "infinity-agent@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
+                        },
+                        "is-stream": {
+                          "version": "1.0.1",
+                          "from": "is-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "2.0.0",
+                          "from": "object-assign@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                        },
+                        "prepend-http": {
+                          "version": "1.0.1",
+                          "from": "prepend-http@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                        },
+                        "read-all-stream": {
+                          "version": "1.0.2",
+                          "from": "read-all-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
+                        },
+                        "statuses": {
+                          "version": "1.2.1",
+                          "from": "statuses@>=1.2.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                        },
+                        "timed-out": {
+                          "version": "2.0.0",
+                          "from": "timed-out@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.0.0",
+                      "from": "registry-url@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.0.tgz",
+                      "dependencies": {
+                        "rc": {
+                          "version": "0.6.0",
+                          "from": "rc@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@>=0.0.7 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "ini@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.0.0",
+              "from": "semver-diff@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz"
+            },
+            "string-length": {
+              "version": "1.0.0",
+              "from": "string-length@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "opn": {
+      "version": "1.0.1",
+      "from": "opn@1.0.1",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "from": "prompt@>=0.2.14 <0.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "dependencies": {
+        "pkginfo": {
+          "version": "0.3.0",
+          "from": "pkginfo@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+        },
+        "revalidator": {
+          "version": "0.1.8",
+          "from": "revalidator@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
+        },
+        "utile": {
+          "version": "0.2.1",
+          "from": "utile@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.9 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "deep-equal": {
+              "version": "1.0.0",
+              "from": "deep-equal@*",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+            },
+            "i": {
+              "version": "0.3.2",
+              "from": "i@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "ncp": {
+              "version": "0.4.2",
+              "from": "ncp@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "winston": {
+          "version": "0.8.3",
+          "from": "winston@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "cycle": {
+              "version": "1.0.3",
+              "from": "cycle@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "from": "eyes@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+            },
+            "isstream": {
+              "version": "0.1.1",
+              "from": "isstream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+            },
+            "stack-trace": {
+              "version": "0.0.9",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "read": {
+      "version": "1.0.5",
+      "from": "read@1.0.5",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.4",
+          "from": "mute-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+        }
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "from": "replace-ext@0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+    },
+    "replacestream": {
+      "version": "2.0.0",
+      "from": "replacestream@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz"
+    },
+    "requirejs": {
+      "version": "2.1.16",
+      "from": "requirejs@>=2.1.16 <3.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz"
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "from": "rimraf@2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+    },
+    "semver": {
+      "version": "4.3.1",
+      "from": "semver@>=4.3.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz"
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "from": "shelljs@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+    },
+    "through": {
+      "version": "2.3.6",
+      "from": "through@2.3.6",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+    },
+    "uglify-js": {
+      "version": "2.4.16",
+      "from": "uglify-js@>=2.4.16 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.1.34",
+          "from": "source-map@0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@>=0.3.5 <0.4.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+        }
+      }
+    },
+    "which": {
+      "version": "1.0.9",
+      "from": "which@1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+    }
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,58 +2,63 @@
   "name": "component-helper",
   "version": "1.2.1",
   "dependencies": {
-    "array-uniq": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+    "ansi": {
+      "version": "0.3.0",
+      "from": "ansi@0.3.0",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+    },
+    "array-slice": {
+      "version": "0.2.2",
+      "from": "array-slice@0.2.2",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
     },
     "autoprefixer": {
       "version": "5.1.0",
-      "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-5.1.0.tgz",
+      "from": "autoprefixer@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-5.1.0.tgz",
       "dependencies": {
         "autoprefixer-core": {
-          "version": "5.1.7",
-          "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.7.tgz",
+          "version": "5.1.8",
+          "from": "autoprefixer-core@>=5.1.0 <5.2.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.8.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz",
+              "from": "browserslist@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
             },
             "num2fraction": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz",
+              "from": "num2fraction@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000081",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000081.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000081.tgz"
+              "version": "1.0.30000109",
+              "from": "caniuse-db@>=1.0.30000106 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000109.tgz"
             }
           }
         },
         "postcss": {
           "version": "4.0.6",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "from": "postcss@>=4.0.2 <4.1.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "from": "source-map@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "js-base64": {
               "version": "2.1.7",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz",
+              "from": "js-base64@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
             }
           }
@@ -61,9 +66,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1.18",
+      "version": "2.1.20",
       "from": "aws-sdk@>=2.1.18 <3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.18.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.20.tgz",
       "dependencies": {
         "xml2js": {
           "version": "0.2.6",
@@ -85,125 +90,174 @@
       }
     },
     "bower": {
-      "version": "1.3.12",
-      "from": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
+      "version": "1.4.0",
+      "from": "bower@>=1.3.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.4.0.tgz",
       "dependencies": {
         "abbrev": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+          "from": "abbrev@>=1.0.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
         },
         "archy": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+          "version": "1.0.0",
+          "from": "archy@1.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
         },
         "bower-config": {
-          "version": "0.5.2",
-          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+          "version": "0.6.0",
+          "from": "bower-config@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "from": "optimist@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+              "from": "osenv@0.0.3",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
         },
         "bower-endpoint-parser": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
           "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
         },
         "bower-json": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "from": "bower-json@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "intersect": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+              "from": "intersect@>=0.0.3 <0.1.0",
               "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "from": "bower-logger@>=0.2.2 <0.3.0",
           "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "bower-registry-client": {
-          "version": "0.2.3",
-          "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.3.tgz",
+          "version": "0.2.4",
+          "from": "bower-registry-client@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.8 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "bower-config": {
+              "version": "0.5.2",
+              "from": "bower-config@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+              "dependencies": {
+                "mout": {
+                  "version": "0.9.1",
+                  "from": "mout@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.0.3",
+                  "from": "osenv@0.0.3",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                }
+              }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "lru-cache": {
               "version": "2.3.1",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+              "from": "lru-cache@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
             },
             "request": {
               "version": "2.51.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "from": "request@>=2.51.0 <2.52.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -211,33 +265,33 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "from": "caseless@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.0.9",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.7.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                         }
                       }
                     }
@@ -245,113 +299,113 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                      "from": "punycode@>=0.2.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -360,177 +414,124 @@
             },
             "request-replay": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+              "from": "request-replay@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
         },
         "cardinal": {
-          "version": "0.4.0",
-          "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
+          "version": "0.4.4",
+          "from": "cardinal@0.4.4",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "dependencies": {
             "redeyed": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "from": "redeyed@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz"
-            }
-          }
-        },
-        "chalk": {
-          "version": "0.5.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "ansicolors@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             }
           }
         },
         "chmodr": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
+          "from": "chmodr@0.1.0",
           "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
         },
         "decompress-zip": {
-          "version": "0.0.8",
-          "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+          "version": "0.1.0",
+          "from": "decompress-zip@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
           "dependencies": {
-            "mkpath": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
-            },
             "binary": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "from": "binary@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "dependencies": {
                 "chainsaw": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                      "from": "traverse@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
                 },
                 "buffers": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "from": "buffers@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
-            "touch": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "1.0.10",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
-                }
-              }
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
-            },
-            "nopt": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
             }
           }
         },
-        "fstream": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz"
-        },
         "fstream-ignore": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "from": "fstream-ignore@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
           "dependencies": {
             "minimatch": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -539,31 +540,65 @@
             }
           }
         },
+        "github": {
+          "version": "0.2.3",
+          "from": "github@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/github/-/github-0.2.3.tgz"
+        },
         "glob": {
-          "version": "4.0.6",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "version": "4.5.3",
+          "from": "glob@>=4.3.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -571,45 +606,45 @@
           }
         },
         "graceful-fs": {
-          "version": "3.0.5",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+          "version": "3.0.6",
+          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
         },
         "handlebars": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "from": "handlebars@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "from": "optimist@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -619,444 +654,135 @@
           }
         },
         "inquirer": {
-          "version": "0.7.1",
-          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
+          "version": "0.8.0",
+          "from": "inquirer@0.8.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
           "dependencies": {
-            "cli-color": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.6",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                  "dependencies": {
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                },
-                "memoizee": {
-                  "version": "0.3.8",
-                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
-                  "dependencies": {
-                    "es6-weak-map": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
-                      "dependencies": {
-                        "es6-iterator": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                          "dependencies": {
-                            "es6-symbol": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "es6-symbol": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                        }
-                      }
-                    },
-                    "event-emitter": {
-                      "version": "0.3.3",
-                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
-                    },
-                    "lru-queue": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
-                    },
-                    "next-tick": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
-                    }
-                  }
-                },
-                "timers-ext": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
-                  "dependencies": {
-                    "next-tick": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "figures": {
-              "version": "1.3.5",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
-            },
-            "lodash": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-            },
-            "mute-stream": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
-            },
-            "readline2": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
-            }
-          }
-        },
-        "insight": {
-          "version": "0.4.3",
-          "from": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             },
             "chalk": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
-            "configstore": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "dependencies": {
-                "js-yaml": {
-                  "version": "3.2.7",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
-                        },
-                        "sprintf-js": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "xdg-basedir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-                }
-              }
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz"
             },
-            "inquirer": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
-              "dependencies": {
-                "cli-color": {
-                  "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.6",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                      "dependencies": {
-                        "es6-iterator": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                        },
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "memoizee": {
-                      "version": "0.3.8",
-                      "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
-                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
-                      "dependencies": {
-                        "es6-weak-map": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                              "dependencies": {
-                                "es6-symbol": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                                }
-                              }
-                            },
-                            "es6-symbol": {
-                              "version": "0.1.1",
-                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                            }
-                          }
-                        },
-                        "event-emitter": {
-                          "version": "0.3.3",
-                          "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
-                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
-                        },
-                        "lru-queue": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
-                        },
-                        "next-tick": {
-                          "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
-                        }
-                      }
-                    },
-                    "timers-ext": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
-                      "dependencies": {
-                        "next-tick": {
-                          "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                },
-                "mute-stream": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
-                },
-                "readline2": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                  "dependencies": {
-                    "strip-ansi": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
-                }
-              }
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz"
+            },
+            "rx": {
+              "version": "2.4.7",
+              "from": "rx@>=2.2.27 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.7.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.5.3",
+          "from": "insight@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "lodash.debounce": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+              "version": "3.0.3",
+              "from": "lodash.debounce@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.0.3.tgz",
               "dependencies": {
-                "lodash.isfunction": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-                },
-                "lodash.isobject": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash.now": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    }
-                  }
+                "lodash.isnative": {
+                  "version": "3.0.1",
+                  "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.1.tgz"
                 }
               }
-            },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             },
             "os-name": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "from": "os-name@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
               "dependencies": {
                 "osx-release": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "from": "osx-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz"
                 },
                 "win-release": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz",
+                  "from": "win-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
                 }
               }
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "from": "tough-cookie@>=0.12.1 <0.13.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@>=0.2.0",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
@@ -1065,523 +791,384 @@
         },
         "is-root": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+          "from": "is-root@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
         },
         "junk": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz",
+          "from": "junk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
         },
         "lockfile": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz",
+          "from": "lockfile@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "from": "lru-cache@>=2.5.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "mout": {
-          "version": "0.9.1",
-          "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+          "version": "0.11.0",
+          "from": "mout@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
         },
         "nopt": {
           "version": "3.0.1",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+          "from": "nopt@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
         },
-        "osenv": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
-        },
         "p-throttler": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
+          "version": "0.1.1",
+          "from": "p-throttler@0.1.1",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+              "from": "q@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "from": "promptly@0.2.0",
           "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz"
         },
         "q": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+          "version": "1.2.0",
+          "from": "q@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.2.0.tgz"
         },
         "request": {
-          "version": "2.42.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+          "version": "2.53.0",
+          "from": "request@2.53.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+              "version": "0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
-            "qs": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            "form-data": {
+              "version": "0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+              "version": "2.0.10",
+              "from": "mime-types@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.8.0",
+                  "from": "mime-db@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                }
+              }
             },
             "node-uuid": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "from": "tough-cookie@>=0.12.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@>=0.2.0",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
-            },
-            "form-data": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-              "dependencies": {
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                },
-                "async": {
-                  "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+              "version": "0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "version": "2.3.1",
+              "from": "hawk@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                  "version": "2.12.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
                 },
                 "boom": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                  "version": "2.6.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
                 },
                 "cryptiles": {
-                  "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                  "version": "2.0.4",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
-                  "version": "0.2.4",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-            }
-          }
-        },
-        "request-progress": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
-          "dependencies": {
-            "throttleit": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             }
           }
         },
         "retry": {
-          "version": "0.6.0",
-          "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+          "version": "0.6.1",
+          "from": "retry@0.6.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
         },
         "semver": {
           "version": "2.3.2",
-          "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+          "from": "semver@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "shell-quote": {
-          "version": "1.4.2",
-          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
+          "version": "1.4.3",
+          "from": "shell-quote@>=1.4.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "from": "jsonify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "array-filter": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+              "from": "array-filter@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+              "from": "array-reduce@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
             "array-map": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+              "from": "array-map@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             }
           }
         },
         "stringify-object": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "stringify-object@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
         },
         "tar-fs": {
-          "version": "0.5.2",
-          "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
+          "version": "1.5.0",
+          "from": "tar-fs@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.5.0.tgz",
           "dependencies": {
             "pump": {
-              "version": "0.3.5",
-              "from": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/once/-/once-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
-                }
-              }
+              "version": "1.0.0",
+              "from": "pump@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz"
             },
             "tar-stream": {
-              "version": "0.4.7",
-              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+              "version": "1.1.2",
+              "from": "tar-stream@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.2.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.33 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.1.0",
+              "from": "end-of-stream@1.1.0",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
                 }
               }
             }
           }
         },
         "tmp": {
-          "version": "0.0.23",
-          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
-        },
-        "update-notifier": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
-          "dependencies": {
-            "configstore": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "dependencies": {
-                "js-yaml": {
-                  "version": "3.2.7",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
-                        },
-                        "sprintf-js": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "xdg-basedir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-                }
-              }
-            },
-            "latest-version": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
-              "dependencies": {
-                "package-json": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
-                  "dependencies": {
-                    "got": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
-                      "dependencies": {
-                        "object-assign": {
-                          "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
-                      "dependencies": {
-                        "npmconf": {
-                          "version": "2.1.1",
-                          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-                          "dependencies": {
-                            "config-chain": {
-                              "version": "1.1.8",
-                              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-                              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-                              "dependencies": {
-                                "proto-list": {
-                                  "version": "1.2.3",
-                                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
-                                }
-                              }
-                            },
-                            "ini": {
-                              "version": "1.3.3",
-                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
-                            },
-                            "once": {
-                              "version": "1.3.1",
-                              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "uid-number": {
-                              "version": "0.0.5",
-                              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz"
-            },
-            "string-length": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "version": "0.0.24",
+          "from": "tmp@0.0.24",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
         }
       }
     },
     "browser-sync": {
-      "version": "2.4.0",
+      "version": "2.5.0",
       "from": "browser-sync@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.5.0.tgz",
       "dependencies": {
         "async-each-series": {
           "version": "0.1.1",
@@ -1594,9 +1181,9 @@
           "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-1.0.2.tgz"
         },
         "browser-sync-ui": {
-          "version": "0.4.11",
-          "from": "browser-sync-ui@>=0.4.11 <0.5.0",
-          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.4.11.tgz",
+          "version": "0.5.2",
+          "from": "browser-sync-ui@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.5.2.tgz",
           "dependencies": {
             "angular": {
               "version": "1.3.15",
@@ -1622,6 +1209,30 @@
               "version": "0.0.5",
               "from": "connect-history-api-fallback@0.0.5",
               "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+            },
+            "stream-throttle": {
+              "version": "0.1.3",
+              "from": "stream-throttle@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.7.1",
+                  "from": "commander@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "limiter": {
+                  "version": "1.0.5",
+                  "from": "limiter@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.0.5.tgz"
+                }
+              }
             },
             "weinre": {
               "version": "2.0.0-pre-I0Z7U9OV",
@@ -1836,9 +1447,9 @@
           "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-0.0.1.tgz"
         },
         "foxy": {
-          "version": "10.0.2",
-          "from": "foxy@>=10.0.2 <11.0.0",
-          "resolved": "https://registry.npmjs.org/foxy/-/foxy-10.0.2.tgz",
+          "version": "10.1.0",
+          "from": "foxy@>=10.1.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/foxy/-/foxy-10.1.0.tgz",
           "dependencies": {
             "cookie": {
               "version": "0.1.2",
@@ -1847,7 +1458,7 @@
             },
             "http-proxy": {
               "version": "1.9.0",
-              "from": "http-proxy@>=1.8.1 <2.0.0",
+              "from": "http-proxy@>=1.9.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.0.tgz",
               "dependencies": {
                 "eventemitter3": {
@@ -1861,71 +1472,18 @@
                   "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
                 }
               }
-            },
-            "meow": {
-              "version": "2.1.0",
-              "from": "meow@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.0",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.2",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.0",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                        },
-                        "meow": {
-                          "version": "3.1.0",
-                          "from": "meow@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                }
-              }
             }
           }
         },
         "glob-watcher": {
-          "version": "0.0.8",
-          "from": "glob-watcher@>=0.0.8 <0.0.9",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz"
+          "version": "2.0.0",
+          "from": "glob-watcher@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-2.0.0.tgz"
         },
         "immutable": {
-          "version": "3.6.4",
+          "version": "3.7.1",
           "from": "immutable@>=3.6.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.6.4.tgz"
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.1.tgz"
         },
         "localtunnel": {
           "version": "1.5.0",
@@ -1983,57 +1541,9 @@
           }
         },
         "lodash": {
-          "version": "3.5.0",
+          "version": "3.6.0",
           "from": "lodash@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-        },
-        "meow": {
-          "version": "3.1.0",
-          "from": "meow@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.0.2",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                },
-                "map-obj": {
-                  "version": "1.0.0",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                }
-              }
-            },
-            "indent-string": {
-              "version": "1.2.1",
-              "from": "indent-string@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "dependencies": {
-                "repeating": {
-                  "version": "1.1.2",
-                  "from": "repeating@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.0",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
         },
         "portscanner": {
           "version": "1.0.0",
@@ -2122,6 +1632,11 @@
               "from": "http-errors@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "statuses": {
                   "version": "1.2.1",
                   "from": "statuses@>=1.0.0 <2.0.0",
@@ -2240,56 +1755,66 @@
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
+      "from": "browserify@>=9.0.3 <10.0.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "from": "JSONStream@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+              "from": "jsonparse@0.0.5",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@>=2.2.7 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "from": "assert@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
-          "version": "4.0.0",
-          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.0.tgz",
+          "version": "4.0.1",
+          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -2298,134 +1823,134 @@
             },
             "umd": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz",
+              "from": "umd@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
             }
           }
         },
         "browser-resolve": {
-          "version": "1.7.2",
-          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz"
+          "version": "1.8.2",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "from": "browserify-zlib@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.5",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+              "version": "0.2.6",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.0.3",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz",
+          "version": "3.1.2",
+          "from": "buffer@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "from": "base64-js@0.0.8",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.4",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
+              "from": "ieee754@>=1.1.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+              "from": "is-array@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+          "from": "builtins@>=0.0.3 <0.1.0",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "from": "commondir@0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.7",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "from": "constants-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.9.13",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "from": "crypto-browserify@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "dependencies": {
             "browserify-aes": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
+              "from": "browserify-aes@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
               "version": "2.8.0",
-              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "from": "browserify-sign@2.8.0",
               "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "browserify-rsa": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
+                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "parse-asn1": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "from": "parse-asn1@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
                     },
                     "asn1.js-rfc3280": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
+                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                     },
                     "pemstrip": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
+                      "from": "pemstrip@0.0.1",
                       "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
@@ -2434,66 +1959,66 @@
             },
             "create-ecdh": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "from": "create-ecdh@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz"
             },
             "create-hash": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "create-hash@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
+                  "from": "ripemd160@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
+              "from": "create-hmac@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "from": "diffie-hellman@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "miller-rabin": {
                   "version": "1.1.5",
-                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                  "from": "miller-rabin@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz"
                 }
               }
             },
             "pbkdf2-compat": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
+              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
             },
             "public-encrypt": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "from": "public-encrypt@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "dependencies": {
                 "browserify-rsa": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
+                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                 },
                 "parse-asn1": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "from": "parse-asn1@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "from": "asn1.js@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -2504,27 +2029,27 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+              "from": "randombytes@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             },
             "bn.js": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+              "from": "bn.js@1.3.0",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
             },
             "brorand": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+              "from": "brorand@1.0.5",
               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
             },
             "elliptic": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+              "from": "elliptic@1.0.1",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
               "dependencies": {
                 "hash.js": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
+                  "from": "hash.js@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                 }
               }
@@ -2533,49 +2058,49 @@
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
-        },
-        "defined": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "from": "deps-sort@>=1.3.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "from": "JSONStream@>=0.8.4 <0.9.0",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+              "from": "minimist@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -2586,49 +2111,54 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+          "from": "domain-browser@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+          "from": "events@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
-          "version": "4.4.1",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+          "version": "4.5.3",
+          "from": "glob@>=4.0.5 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2637,12 +2167,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -2651,56 +2181,56 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
+          "from": "has@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "from": "http-browserify@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+          "from": "https-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "insert-module-globals": {
-          "version": "6.2.0",
-          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
+          "version": "6.2.1",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "lexical-scope": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "from": "lexical-scope@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                  "from": "astw@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "3001.1.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
@@ -2709,24 +2239,24 @@
             },
             "process": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+              "from": "process@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             }
           }
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "from": "stream-splicer@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 }
               }
@@ -2734,97 +2264,102 @@
           }
         },
         "module-deps": {
-          "version": "3.7.2",
-          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
+          "version": "3.7.3",
+          "from": "module-deps@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.3.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "from": "JSONStream@>=0.7.1 <0.8.0",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                  "from": "jsonparse@0.0.5",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "detective": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+              "from": "detective@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+                  "from": "acorn@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "from": "escodegen@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
-                      "version": "1.9.1",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+                      "version": "1.9.3",
+                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                      "from": "esutils@>=1.1.6 <2.0.0",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
-                      "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
+                      "version": "1.2.5",
+                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "from": "optionator@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
+                          "from": "prelude-ls@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                          "from": "deep-is@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "from": "type-check@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                          "from": "levn@>=0.2.5 <0.3.0",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@>=0.1.40 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -2835,34 +2370,34 @@
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+              "from": "minimist@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "from": "stream-combiner2@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                      "from": "xtend@>=3.0.0 <3.1.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
@@ -2871,41 +2406,41 @@
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+              "from": "subarg@0.0.1",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.7 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "from": "through2@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "from": "xtend@>=2.1.1 <2.2.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "from": "object-keys@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -2914,83 +2449,83 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "from": "parents@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+              "from": "path-platform@>=0.11.15 <0.12.0",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "from": "path-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
-          "version": "0.10.0",
-          "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+          "version": "0.10.1",
+          "from": "process@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+          "from": "punycode@>=1.2.3 <1.3.0",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
-          "version": "1.1.5",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+          "version": "1.1.6",
+          "from": "resolve@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+          "from": "shallow-copy@0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+          "from": "shasum@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
@@ -2999,108 +2534,113 @@
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+          "from": "shell-quote@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "from": "subarg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
         },
         "syntax-error": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+          "from": "syntax-error@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
+              "from": "acorn@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "from": "through2@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "from": "tty-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
-          "version": "0.10.2",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
+          "version": "0.10.3",
+          "from": "url@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "from": "vm-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "from": "xtend@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         },
         "sha.js": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+          "from": "sha.js@2.3.6",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
         },
         "combine-source-map": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+          "from": "combine-source-map@0.3.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
           "dependencies": {
             "inline-source-map": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+              "from": "inline-source-map@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                  "from": "source-map@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -3109,12 +2649,12 @@
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "from": "source-map@>=0.1.31 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -3125,78 +2665,540 @@
     },
     "chalk": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+      "from": "chalk@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+          "from": "ansi-styles@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "has-ansi": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "from": "has-ansi@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             }
           }
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.0.tgz"
+          "version": "1.3.1",
+          "from": "supports-color@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
         }
       }
     },
     "chokidar": {
-      "version": "1.0.0-rc4",
+      "version": "1.0.0-rc5",
       "from": "chokidar@>=1.0.0-rc4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc4.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc5.tgz",
       "dependencies": {
         "anymatch": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "from": "anymatch@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.2.1.tgz",
           "dependencies": {
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+            "micromatch": {
+              "version": "2.1.5",
+              "from": "micromatch@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.5.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                "arr-diff": {
+                  "version": "1.0.1",
+                  "from": "arr-diff@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz"
                 },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                "braces": {
+                  "version": "1.8.0",
+                  "from": "braces@>=1.8.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                  "dependencies": {
+                    "expand-range": {
+                      "version": "1.8.1",
+                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                      "dependencies": {
+                        "fill-range": {
+                          "version": "2.2.0",
+                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.0.tgz",
+                          "dependencies": {
+                            "is-number": {
+                              "version": "1.1.2",
+                              "from": "is-number@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                            },
+                            "randomatic": {
+                              "version": "1.1.0",
+                              "from": "randomatic@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.0",
+                              "from": "repeat-string@>=1.5.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "preserve": {
+                      "version": "0.2.0",
+                      "from": "preserve@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                    },
+                    "repeat-element": {
+                      "version": "1.1.0",
+                      "from": "repeat-element@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.0.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.1.3",
+                  "from": "debug@>=2.1.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.0",
+                      "from": "ms@0.7.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.1",
+                  "from": "expand-brackets@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                },
+                "filename-regex": {
+                  "version": "2.0.0",
+                  "from": "filename-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                },
+                "kind-of": {
+                  "version": "1.1.0",
+                  "from": "kind-of@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                },
+                "object.omit": {
+                  "version": "0.2.1",
+                  "from": "object.omit@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz"
+                },
+                "parse-glob": {
+                  "version": "3.0.0",
+                  "from": "parse-glob@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.0.tgz",
+                  "dependencies": {
+                    "glob-base": {
+                      "version": "0.2.0",
+                      "from": "glob-base@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                    },
+                    "is-dotfile": {
+                      "version": "1.0.0",
+                      "from": "is-dotfile@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.3.0",
+                  "from": "regex-cache@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.3.0.tgz",
+                  "dependencies": {
+                    "benchmarked": {
+                      "version": "0.1.4",
+                      "from": "benchmarked@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/benchmarked/-/benchmarked-0.1.4.tgz",
+                      "dependencies": {
+                        "benchmark": {
+                          "version": "1.0.0",
+                          "from": "benchmark@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                        },
+                        "chalk": {
+                          "version": "1.0.0",
+                          "from": "chalk@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.0.1",
+                              "from": "ansi-styles@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "1.0.3",
+                              "from": "has-ansi@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "1.1.1",
+                                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                },
+                                "get-stdin": {
+                                  "version": "4.0.1",
+                                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "2.0.1",
+                              "from": "strip-ansi@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "1.1.1",
+                                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "1.3.1",
+                              "from": "supports-color@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                            }
+                          }
+                        },
+                        "extend-shallow": {
+                          "version": "1.1.2",
+                          "from": "extend-shallow@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+                        },
+                        "file-reader": {
+                          "version": "1.0.0",
+                          "from": "file-reader@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/file-reader/-/file-reader-1.0.0.tgz",
+                          "dependencies": {
+                            "extend-shallow": {
+                              "version": "0.2.0",
+                              "from": "extend-shallow@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz",
+                              "dependencies": {
+                                "array-slice": {
+                                  "version": "0.2.2",
+                                  "from": "array-slice@>=0.2.2 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+                                }
+                              }
+                            },
+                            "map-files": {
+                              "version": "0.3.0",
+                              "from": "map-files@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/map-files/-/map-files-0.3.0.tgz",
+                              "dependencies": {
+                                "globby": {
+                                  "version": "0.1.1",
+                                  "from": "globby@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/globby/-/globby-0.1.1.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "0.1.0",
+                                      "from": "array-differ@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
+                                    },
+                                    "array-union": {
+                                      "version": "0.1.0",
+                                      "from": "array-union@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+                                      "dependencies": {
+                                        "array-uniq": {
+                                          "version": "0.1.1",
+                                          "from": "array-uniq@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "async": {
+                                      "version": "0.9.0",
+                                      "from": "async@>=0.9.0 <0.10.0",
+                                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                    },
+                                    "glob": {
+                                      "version": "4.5.3",
+                                      "from": "glob@>=4.0.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                                      "dependencies": {
+                                        "inflight": {
+                                          "version": "1.0.4",
+                                          "from": "inflight@>=1.0.4 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "minimatch": {
+                                          "version": "2.0.4",
+                                          "from": "minimatch@>=2.0.1 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                                          "dependencies": {
+                                            "brace-expansion": {
+                                              "version": "1.1.0",
+                                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                              "dependencies": {
+                                                "balanced-match": {
+                                                  "version": "0.2.0",
+                                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                                },
+                                                "concat-map": {
+                                                  "version": "0.0.1",
+                                                  "from": "concat-map@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "once": {
+                                          "version": "1.3.1",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "relative": {
+                                  "version": "0.1.6",
+                                  "from": "relative@>=0.1.6 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/relative/-/relative-0.1.6.tgz",
+                                  "dependencies": {
+                                    "normalize-path": {
+                                      "version": "0.1.1",
+                                      "from": "normalize-path@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-0.1.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-yaml": {
+                              "version": "1.0.0",
+                              "from": "read-yaml@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-yaml/-/read-yaml-1.0.0.tgz",
+                              "dependencies": {
+                                "js-yaml": {
+                                  "version": "3.2.7",
+                                  "from": "js-yaml@>=3.2.3 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                                  "dependencies": {
+                                    "argparse": {
+                                      "version": "1.0.2",
+                                      "from": "argparse@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                                      "dependencies": {
+                                        "lodash": {
+                                          "version": "3.6.0",
+                                          "from": "lodash@>=3.2.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                                        },
+                                        "sprintf-js": {
+                                          "version": "1.0.2",
+                                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "esprima": {
+                                      "version": "2.0.0",
+                                      "from": "esprima@>=2.0.0 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "has-values": {
+                          "version": "0.1.3",
+                          "from": "has-values@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+                        }
+                      }
+                    },
+                    "chalk": {
+                      "version": "0.5.1",
+                      "from": "chalk@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "1.1.0",
+                          "from": "ansi-styles@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "0.1.0",
+                          "from": "has-ansi@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "0.2.1",
+                              "from": "ansi-regex@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "0.3.0",
+                          "from": "strip-ansi@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "0.2.1",
+                              "from": "ansi-regex@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "0.2.0",
+                          "from": "supports-color@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "micromatch": {
+                      "version": "1.6.2",
+                      "from": "micromatch@>=1.2.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-1.6.2.tgz",
+                      "dependencies": {
+                        "extglob": {
+                          "version": "0.2.0",
+                          "from": "extglob@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.2.0.tgz"
+                        },
+                        "parse-glob": {
+                          "version": "2.1.1",
+                          "from": "parse-glob@>=2.1.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.1.1.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.1.1",
+                              "from": "glob-base@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.1.1.tgz"
+                            },
+                            "glob-path-regex": {
+                              "version": "1.0.0",
+                              "from": "glob-path-regex@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-key": {
+                      "version": "1.0.0",
+                      "from": "to-key@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-key/-/to-key-1.0.0.tgz",
+                      "dependencies": {
+                        "arr-map": {
+                          "version": "1.0.0",
+                          "from": "arr-map@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-1.0.0.tgz"
+                        },
+                        "for-in": {
+                          "version": "0.1.4",
+                          "from": "for-in@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "isobject": {
+                  "version": "0.2.0",
+                  "from": "isobject@0.2.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                },
+                "for-own": {
+                  "version": "0.1.3",
+                  "from": "for-own@0.1.3",
+                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                  "dependencies": {
+                    "for-in": {
+                      "version": "0.1.4",
+                      "from": "for-in@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                    }
+                  }
                 }
               }
             }
           }
+        },
+        "arrify": {
+          "version": "1.0.0",
+          "from": "arrify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
         },
         "async-each": {
           "version": "0.1.6",
@@ -3206,14 +3208,7 @@
         "glob-parent": {
           "version": "1.2.0",
           "from": "glob-parent@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
-          "dependencies": {
-            "is-glob": {
-              "version": "1.1.3",
-              "from": "is-glob@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
         },
         "is-binary-path": {
           "version": "1.0.0",
@@ -3226,6 +3221,11 @@
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
             }
           }
+        },
+        "is-glob": {
+          "version": "1.1.3",
+          "from": "is-glob@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
         },
         "readdirp": {
           "version": "1.3.0",
@@ -3264,10 +3264,20 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -3289,64 +3299,96 @@
     },
     "colors": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "from": "colors@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+    },
+    "configstore": {
+      "version": "0.3.2",
+      "from": "configstore@0.3.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.6",
+          "from": "graceful-fs@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+        },
+        "js-yaml": {
+          "version": "3.2.7",
+          "from": "js-yaml@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "from": "argparse@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.6.0",
+                  "from": "lodash@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.0.0",
+              "from": "esprima@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "from": "uuid@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+        },
+        "xdg-basedir": {
+          "version": "1.0.1",
+          "from": "xdg-basedir@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+        }
+      }
     },
     "convert-source-map": {
       "version": "0.3.5",
-      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+      "from": "convert-source-map@0.3.5",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
     },
-    "dateformat": {
-      "version": "1.0.11",
-      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+    "d": {
+      "version": "0.1.1",
+      "from": "d@0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "dependencies": {
-        "meow": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+        "es5-ext": {
+          "version": "0.10.6",
+          "from": "es5-ext@>=0.10.2 <0.11.0",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
           "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                },
-                "map-obj": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                }
-              }
+            "es6-iterator": {
+              "version": "0.1.3",
+              "from": "es6-iterator@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
             },
-            "indent-string": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "dependencies": {
-                "repeating": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            "es6-symbol": {
+              "version": "2.0.1",
+              "from": "es6-symbol@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
             }
           }
         }
@@ -3354,81 +3396,98 @@
     },
     "deep-extend": {
       "version": "0.2.11",
-      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+      "from": "deep-extend@0.2.11",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+    },
+    "defined": {
+      "version": "0.0.0",
+      "from": "defined@0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
     },
     "del": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
+      "from": "del@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "globby": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "from": "globby@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
           "dependencies": {
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
             },
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "glob": {
-              "version": "4.4.1",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+              "version": "4.5.3",
+              "from": "glob@>=4.4.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
-                "minimatch": {
+                "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -3437,12 +3496,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3453,128 +3512,143 @@
         },
         "is-path-cwd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "from": "is-path-cwd@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
         },
         "is-path-in-cwd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
           "dependencies": {
             "is-path-inside": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+              "from": "is-path-inside@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
               "dependencies": {
                 "path-is-inside": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+                  "from": "path-is-inside@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
                 }
               }
             }
           }
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.6",
+      "from": "es5-ext@0.10.6",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+      "dependencies": {
+        "es6-iterator": {
+          "version": "0.1.3",
+          "from": "es6-iterator@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "from": "d@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+            }
+          }
         },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-        }
-      }
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+        "es6-symbol": {
+          "version": "2.0.1",
+          "from": "es6-symbol@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
           "dependencies": {
-            "core-util-is": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            "d": {
+              "version": "0.1.1",
+              "from": "d@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             }
           }
         }
       }
     },
-    "end-of-stream": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+    "es6-iterator": {
+      "version": "0.1.3",
+      "from": "es6-iterator@0.1.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
       "dependencies": {
-        "once": {
-          "version": "1.3.1",
-          "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-            }
-          }
+        "es6-symbol": {
+          "version": "2.0.1",
+          "from": "es6-symbol@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
         }
       }
     },
     "es6-promise": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz",
+      "from": "es6-promise@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz"
+    },
+    "es6-symbol": {
+      "version": "0.1.1",
+      "from": "es6-symbol@0.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
     },
     "esprima": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "from": "esprima@1.0.4",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+    },
+    "event-emitter": {
+      "version": "0.3.3",
+      "from": "event-emitter@0.3.3",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+    },
+    "exit": {
+      "version": "0.1.2",
+      "from": "exit@0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "findup-sync": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+      "from": "findup-sync@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "dependencies": {
         "glob": {
           "version": "4.3.5",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "from": "glob@>=4.3.0 <4.4.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
-            "minimatch": {
+            "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3583,12 +3657,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -3614,51 +3688,75 @@
         }
       }
     },
+    "fstream": {
+      "version": "1.0.4",
+      "from": "fstream@1.0.4",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.6",
+          "from": "graceful-fs@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        }
+      }
+    },
     "gaze": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+      "from": "gaze@0.5.1",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
       "dependencies": {
         "globule": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+          "from": "globule@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
           "dependencies": {
             "lodash": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "lodash@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
             },
             "glob": {
               "version": "3.1.21",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "from": "glob@>=3.1.21 <3.2.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                  "from": "graceful-fs@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                  "from": "inherits@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3669,47 +3767,47 @@
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "from": "get-stdin@4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "gh-pages": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.2.0.tgz",
+      "from": "gh-pages@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.2.0.tgz",
       "dependencies": {
         "q": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+          "from": "q@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
         },
         "q-io": {
           "version": "1.11.6",
-          "from": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
+          "from": "q-io@>=1.11.0 <1.12.0",
           "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
           "dependencies": {
             "qs": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "from": "qs@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "url2": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
+              "from": "url2@>=0.0.0 <0.0.1",
               "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
             },
             "mimeparse": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
+              "from": "mimeparse@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
             },
             "collections": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+              "from": "collections@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
               "dependencies": {
                 "weak-map": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
+                  "from": "weak-map@1.0.0",
                   "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
                 }
               }
@@ -3718,59 +3816,64 @@
         },
         "graceful-fs": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz",
+          "from": "graceful-fs@2.0.1",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz"
         },
         "async": {
           "version": "0.2.9",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "from": "async@0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
         },
         "wrench": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.1.tgz",
+          "from": "wrench@1.5.1",
           "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.1.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "glob": {
           "version": "4.0.6",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "from": "glob@>=4.0.2 <4.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "3.0.5",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -3800,6 +3903,11 @@
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.1",
@@ -3854,10 +3962,20 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -3883,48 +4001,7 @@
             "es6-set": {
               "version": "0.1.1",
               "from": "es6-set@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.6",
-                  "from": "es5-ext@>=0.10.4 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                },
-                "es6-iterator": {
-                  "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                },
-                "es6-symbol": {
-                  "version": "0.1.1",
-                  "from": "es6-symbol@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                },
-                "event-emitter": {
-                  "version": "0.3.3",
-                  "from": "event-emitter@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
             },
             "through2-filter": {
               "version": "1.4.1",
@@ -3955,10 +4032,20 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -3973,109 +4060,109 @@
     },
     "html-minifier": {
       "version": "0.7.0",
-      "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.0.tgz",
+      "from": "html-minifier@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.0.tgz",
       "dependencies": {
         "change-case": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/change-case/-/change-case-2.2.0.tgz",
+          "from": "change-case@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.2.0.tgz",
           "dependencies": {
             "camel-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz",
+              "from": "camel-case@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
             },
             "constant-case": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz",
+              "from": "constant-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
             },
             "dot-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
+              "from": "dot-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
             },
             "is-lower-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
+              "from": "is-lower-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
             },
             "is-upper-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
+              "from": "is-upper-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
             },
             "lower-case": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
+              "from": "lower-case@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
             },
             "param-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
+              "from": "param-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
             },
             "pascal-case": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz",
+              "from": "pascal-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
             },
             "path-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
+              "from": "path-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
             },
             "sentence-case": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
+              "from": "sentence-case@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
             },
             "snake-case": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
+              "from": "snake-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
             },
             "swap-case": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz",
+              "from": "swap-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
             },
             "title-case": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz",
+              "from": "title-case@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
             },
             "upper-case": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
+              "from": "upper-case@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
             },
             "upper-case-first": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.0.tgz"
+              "version": "1.1.1",
+              "from": "upper-case-first@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
             }
           }
         },
         "clean-css": {
           "version": "3.0.10",
-          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.10.tgz",
+          "from": "clean-css@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.10.tgz",
           "dependencies": {
             "commander": {
               "version": "2.5.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+              "from": "commander@>=2.5.0 <2.6.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "from": "source-map@>=0.1.43 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -4083,44 +4170,44 @@
           }
         },
         "cli": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+          "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
               }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             }
           }
         },
         "relateurl": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
+          "from": "relateurl@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
         }
       }
@@ -4132,12 +4219,17 @@
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "from": "inherits@2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "ini": {
+      "version": "1.3.3",
+      "from": "ini@1.3.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isstream": {
@@ -4147,95 +4239,95 @@
     },
     "jade": {
       "version": "1.9.2",
-      "from": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
+      "from": "jade@>=1.9.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
       "dependencies": {
         "character-parser": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
+          "from": "character-parser@1.2.1",
           "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
         },
         "commander": {
           "version": "2.6.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "from": "commander@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "constantinople": {
           "version": "3.0.1",
-          "from": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz",
+          "from": "constantinople@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "transformers": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+          "from": "transformers@2.1.0",
           "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
           "dependencies": {
             "promise": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "from": "promise@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
               "dependencies": {
                 "is-promise": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                  "from": "is-promise@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                 }
               }
             },
             "css": {
               "version": "1.0.8",
-              "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "from": "css@>=1.0.8 <1.1.0",
               "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
               "dependencies": {
                 "css-parse": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                  "from": "css-parse@1.0.4",
                   "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                 },
                 "css-stringify": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                  "from": "css-stringify@1.0.5",
                   "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.2.5",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "from": "uglify-js@>=2.2.5 <2.3.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "from": "optimist@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -4246,30 +4338,66 @@
         },
         "void-elements": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+          "from": "void-elements@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
         },
         "with": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/with/-/with-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/with/-/with-4.0.1.tgz",
+          "version": "4.0.2",
+          "from": "with@>=4.0.0 <4.1.0",
+          "resolved": "https://registry.npmjs.org/with/-/with-4.0.2.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+              "version": "1.0.1",
+              "from": "acorn@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.1.tgz"
             }
           }
         },
         "acorn-globals": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
+          "version": "1.0.3",
+          "from": "acorn-globals@1.0.3",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.3.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+              "version": "1.0.1",
+              "from": "acorn@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "jasmine": {
+      "version": "2.2.1",
+      "from": "jasmine@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.2.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@>=3.2.11 <4.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
             }
           }
         }
@@ -4277,7 +4405,7 @@
     },
     "jasmine-core": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz",
+      "from": "jasmine-core@>=2.1.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz"
     },
     "karma": {
@@ -4310,10 +4438,20 @@
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -4343,6 +4481,11 @@
           "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
             "minimatch": {
               "version": "0.3.0",
               "from": "minimatch@>=0.3.0 <0.4.0",
@@ -4384,10 +4527,10 @@
           "from": "expand-braces@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.1.tgz",
           "dependencies": {
-            "array-slice": {
-              "version": "0.2.2",
-              "from": "array-slice@>=0.2.2 <0.3.0",
-              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
             },
             "braces": {
               "version": "0.1.5",
@@ -4495,7 +4638,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@>=2.4.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mime": {
@@ -4523,10 +4666,20 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -4676,6 +4829,11 @@
                   "from": "http-errors@>=1.2.8 <1.3.0",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "statuses": {
                       "version": "1.2.1",
                       "from": "statuses@>=1.0.0 <2.0.0",
@@ -4826,10 +4984,20 @@
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -5066,227 +5234,128 @@
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
-        },
-        "memoizee": {
-          "version": "0.3.8",
-          "from": "memoizee@>=0.3.8 <0.4.0",
-          "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
-          "dependencies": {
-            "d": {
-              "version": "0.1.1",
-              "from": "d@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-            },
-            "es5-ext": {
-              "version": "0.10.6",
-              "from": "es5-ext@>=0.10.4 <0.11.0",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-              "dependencies": {
-                "es6-iterator": {
-                  "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                },
-                "es6-symbol": {
-                  "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                }
-              }
-            },
-            "es6-weak-map": {
-              "version": "0.1.2",
-              "from": "es6-weak-map@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
-              "dependencies": {
-                "es6-iterator": {
-                  "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                },
-                "es6-symbol": {
-                  "version": "0.1.1",
-                  "from": "es6-symbol@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                }
-              }
-            },
-            "event-emitter": {
-              "version": "0.3.3",
-              "from": "event-emitter@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
-            },
-            "lru-queue": {
-              "version": "0.1.0",
-              "from": "lru-queue@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
-            },
-            "next-tick": {
-              "version": "0.2.2",
-              "from": "next-tick@>=0.2.2 <0.3.0",
-              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
-            },
-            "timers-ext": {
-              "version": "0.1.0",
-              "from": "timers-ext@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
-            }
-          }
         }
       }
     },
     "karma-browserify": {
-      "version": "4.0.0",
-      "from": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.0.0.tgz",
+      "version": "4.1.2",
+      "from": "karma-browserify@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.1.2.tgz",
       "dependencies": {
         "hat": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+          "from": "hat@0.0.3",
           "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz"
         },
         "js-string-escape": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz",
+          "from": "js-string-escape@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "from": "minimatch@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "os-shim": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz",
+          "from": "os-shim@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz"
         },
         "watchify": {
-          "version": "2.4.0",
-          "from": "https://registry.npmjs.org/watchify/-/watchify-2.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.4.0.tgz",
+          "version": "3.1.0",
+          "from": "watchify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
           "dependencies": {
-            "chokidar": {
-              "version": "0.12.6",
-              "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+            "outpipe": {
+              "version": "1.1.0",
+              "from": "outpipe@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.0.tgz",
               "dependencies": {
-                "readdirp": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                "shell-quote": {
+                  "version": "1.4.3",
+                  "from": "shell-quote@>=1.4.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
                   "dependencies": {
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
+                    "array-filter": {
+                      "version": "0.0.1",
+                      "from": "array-filter@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                     },
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
-                },
-                "fsevents": {
-                  "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
-                  "dependencies": {
-                    "nan": {
-                      "version": "1.5.3",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                    "array-reduce": {
+                      "version": "0.0.0",
+                      "from": "array-reduce@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                    },
+                    "array-map": {
+                      "version": "0.0.0",
+                      "from": "array-map@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "through2": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "version": "0.6.3",
+              "from": "through2@>=0.6.3 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
-                },
-                "xtend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         }
@@ -5294,52 +5363,84 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.7",
-      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz",
+      "from": "karma-chrome-launcher@>=0.1.7 <0.2.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz"
     },
     "karma-coverage": {
       "version": "0.2.6",
-      "from": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.2.6.tgz",
+      "from": "karma-coverage@0.2.6",
       "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.2.6.tgz",
       "dependencies": {
         "istanbul": {
-          "version": "0.3.7",
-          "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.7.tgz",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.7.tgz",
+          "version": "0.3.13",
+          "from": "istanbul@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.13.tgz",
           "dependencies": {
             "esprima": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+              "version": "2.1.0",
+              "from": "esprima@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.1.0.tgz"
             },
             "escodegen": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+              "version": "1.6.1",
+              "from": "escodegen@>=1.6.0 <1.7.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
-                "esutils": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
-                },
                 "estraverse": {
-                  "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "esprima": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.1",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.6",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                    }
+                  }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.40 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -5347,36 +5448,48 @@
               }
             },
             "handlebars": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+              "version": "3.0.0",
+              "from": "handlebars@3.0.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
               "dependencies": {
                 "optimist": {
-                  "version": "0.3.7",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
-                    "source-map": {
-                      "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     }
                   }
                 }
@@ -5384,90 +5497,107 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "from": "nopt@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
             },
             "fileset": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "from": "fileset@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-                }
-              }
-            },
-            "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "supports-color": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
-            },
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            },
-            "resolve": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
-            },
-            "js-yaml": {
-              "version": "3.2.7",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                  "from": "glob@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
               }
             },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.6.0",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.0.0",
+                  "from": "esprima@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                }
+              }
+            },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -5476,59 +5606,66 @@
         },
         "ibrik": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/ibrik/-/ibrik-1.1.1.tgz",
+          "from": "ibrik@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/ibrik/-/ibrik-1.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "coffee-script-redux": {
               "version": "2.0.0-beta8",
-              "from": "https://registry.npmjs.org/coffee-script-redux/-/coffee-script-redux-2.0.0-beta8.tgz",
+              "from": "coffee-script-redux@2.0.0-beta8",
               "resolved": "https://registry.npmjs.org/coffee-script-redux/-/coffee-script-redux-2.0.0-beta8.tgz",
               "dependencies": {
                 "StringScanner": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz",
+                  "from": "StringScanner@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz"
                 },
                 "nopt": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+                  "from": "nopt@>=2.1.2 <2.2.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "esmangle": {
                   "version": "0.0.17",
-                  "from": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
+                  "from": "esmangle@>=0.0.8 <0.1.0",
                   "resolved": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
                   "dependencies": {
                     "escope": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/escope/-/escope-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.1.tgz"
+                      "version": "1.0.3",
+                      "from": "escope@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.3.tgz",
+                      "dependencies": {
+                        "estraverse": {
+                          "version": "2.0.0",
+                          "from": "estraverse@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+                        }
+                      }
                     },
                     "estraverse": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+                      "from": "estraverse@>=1.3.2 <1.4.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                     },
                     "esshorten": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
+                      "from": "esshorten@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz",
+                          "from": "estraverse@>=1.2.0 <1.3.0",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz"
                         }
                       }
@@ -5537,24 +5674,29 @@
                 },
                 "source-map": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.11.tgz",
+                  "from": "source-map@0.1.11",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.11.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "escodegen": {
                   "version": "0.0.28",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+                  "from": "escodegen@>=0.0.24 <0.1.0",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                   "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    },
                     "estraverse": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+                      "from": "estraverse@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                     }
                   }
@@ -5568,37 +5710,37 @@
             },
             "istanbul": {
               "version": "0.2.16",
-              "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
+              "from": "istanbul@>=0.2.4 <0.3.0",
               "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                  "from": "esprima@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "escodegen": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+                  "from": "escodegen@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+                      "from": "esutils@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                     },
                     "esprima": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+                      "from": "esprima@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@>=0.1.33 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -5607,32 +5749,32 @@
                 },
                 "handlebars": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+                  "from": "handlebars@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
                   "dependencies": {
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     },
                     "uglify-js": {
                       "version": "2.3.6",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                      "from": "uglify-js@>=2.3.0 <2.4.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                          "from": "async@>=0.2.6 <0.3.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@>=0.1.7 <0.2.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -5643,78 +5785,85 @@
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "from": "nopt@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
                 },
                 "fileset": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+                  "from": "fileset@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "3.2.11",
-                      "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
+                      "from": "glob@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 },
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+                  "from": "abbrev@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "resolve": {
                   "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+                  "from": "resolve@>=0.7.0 <0.8.0",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
                 },
                 "js-yaml": {
                   "version": "3.2.7",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                  "from": "js-yaml@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "dependencies": {
                     "argparse": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                       "dependencies": {
                         "lodash": {
-                          "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                          "version": "3.6.0",
+                          "from": "lodash@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
+                      "from": "esprima@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                     }
                   }
@@ -5723,27 +5872,32 @@
             },
             "estraverse": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+              "from": "estraverse@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
             },
             "escodegen": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+              "from": "escodegen@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
               "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                },
                 "esutils": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+                  "from": "esutils@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.30 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -5752,41 +5906,46 @@
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "from": "optimist@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             }
           }
         },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@>=1.0.6 <1.1.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+        },
         "minimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
@@ -5795,133 +5954,73 @@
     },
     "karma-html2js-preprocessor": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz",
+      "from": "karma-html2js-preprocessor@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.5",
-      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz",
+      "from": "karma-jasmine@>=0.3.3 <0.4.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
     },
     "karma-phantomjs-launcher": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
+      "from": "karma-phantomjs-launcher@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
       "dependencies": {
         "phantomjs": {
-          "version": "1.9.15",
-          "from": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
-          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
+          "version": "1.9.16",
+          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.16.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+              "from": "adm-zip@0.4.4",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
             },
             "kew": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz",
+              "from": "kew@0.4.0",
               "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
-            },
-            "npmconf": {
-              "version": "2.0.9",
-              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.8",
-                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
-                    }
-                  }
-                },
-                "ini": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-                }
-              }
             },
             "progress": {
               "version": "1.1.8",
-              "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+              "from": "progress@1.1.8",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
             "request": {
               "version": "2.42.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "from": "request@2.42.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -5929,155 +6028,203 @@
                 },
                 "caseless": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
+                  "from": "caseless@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+                  "from": "qs@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                      "from": "punycode@>=0.2.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "from": "form-data@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.2.11",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                      "from": "mime@>=1.2.11 <1.3.0",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "memoizee": {
+      "version": "0.3.8",
+      "from": "memoizee@0.3.8",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+      "dependencies": {
+        "es6-weak-map": {
+          "version": "0.1.2",
+          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz"
+        },
+        "lru-queue": {
+          "version": "0.1.0",
+          "from": "lru-queue@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+        }
+      }
+    },
+    "meow": {
+      "version": "3.1.0",
+      "from": "meow@3.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+      "dependencies": {
+        "camelcase-keys": {
+          "version": "1.0.0",
+          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "1.0.2",
+              "from": "camelcase@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
             },
-            "request-progress": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+            "map-obj": {
+              "version": "1.0.0",
+              "from": "map-obj@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+            }
+          }
+        },
+        "indent-string": {
+          "version": "1.2.1",
+          "from": "indent-string@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+          "dependencies": {
+            "repeating": {
+              "version": "1.1.2",
+              "from": "repeating@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
               "dependencies": {
-                "throttleit": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                "is-finite": {
+                  "version": "1.0.0",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                 }
               }
             }
@@ -6087,7 +6234,7 @@
     },
     "mime": {
       "version": "1.3.4",
-      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "from": "mime@>=1.2.11 <2.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "minimist": {
@@ -6096,310 +6243,239 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
     },
     "mustache": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+      "version": "1.2.0",
+      "from": "mustache@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.2.0.tgz"
+    },
+    "mute-stream": {
+      "version": "0.0.4",
+      "from": "mute-stream@0.0.4",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
     },
     "ncp": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "from": "ncp@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
     },
+    "next-tick": {
+      "version": "0.2.2",
+      "from": "next-tick@0.2.2",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+    },
     "node-sass": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
+      "version": "2.1.1",
+      "from": "node-sass@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.1.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "cross-spawn": {
-          "version": "0.2.6",
-          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
+          "version": "0.2.8",
+          "from": "cross-spawn@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.8.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-            }
-          }
-        },
-        "meow": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                },
-                "map-obj": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                }
-              }
-            },
-            "indent-string": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "dependencies": {
-                "repeating": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "mocha": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
+          "version": "2.2.1",
+          "from": "mocha@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.1.tgz",
           "dependencies": {
             "commander": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+              "from": "commander@2.3.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
             },
             "debug": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "from": "debug@2.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "diff": {
               "version": "1.0.8",
-              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+              "from": "diff@1.0.8",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.3",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+              "from": "glob@3.2.3",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "growl": {
               "version": "1.8.1",
-              "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+              "from": "growl@1.8.1",
               "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
             },
             "jade": {
               "version": "0.26.3",
-              "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "from": "jade@0.26.3",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                  "from": "commander@0.6.1",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                  "from": "mkdirp@0.3.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                 }
               }
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "from": "supports-color@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
             }
           }
         },
         "nan": {
-          "version": "1.6.2",
-          "from": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+          "version": "1.7.0",
+          "from": "nan@>=1.6.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
         },
-        "npmconf": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-          "dependencies": {
-            "config-chain": {
-              "version": "1.1.8",
-              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
-                }
-              }
-            },
-            "ini": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
-            },
-            "nopt": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
-            },
-            "uid-number": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "replace-ext@0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "request": {
-          "version": "2.53.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "version": "2.54.0",
+          "from": "request@>=2.53.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.54.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -6407,198 +6483,314 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+              "from": "caseless@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
-              "version": "0.5.2",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+              "version": "0.6.0",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.0.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
-              "version": "2.0.9",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+              "version": "2.0.10",
+              "from": "mime-types@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                  "version": "1.8.0",
+                  "from": "mime-db@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             },
             "node-uuid": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+              "version": "2.4.1",
+              "from": "qs@>=2.4.0 <2.5.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "from": "tough-cookie@>=0.12.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@>=0.2.0",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.11.0",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+                  "version": "2.12.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
                 },
                 "boom": {
                   "version": "2.6.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+                  "from": "boom@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "isstream": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "har-validator": {
+              "version": "1.5.1",
+              "from": "har-validator@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.5.1.tgz",
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.9.21",
+                  "from": "bluebird@>=2.9.14 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz"
+                },
+                "chalk": {
+                  "version": "1.0.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.0.1",
+                      "from": "ansi-styles@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "1.0.3",
+                      "from": "has-ansi@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "1.3.1",
+                      "from": "supports-color@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.7.1",
+                  "from": "commander@>=2.7.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.10.0",
+                  "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.1.1",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "1.1.0",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
             }
           }
         },
         "sass-graph": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
+          "version": "1.2.0",
+          "from": "sass-graph@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.2.0.tgz",
           "dependencies": {
             "commander": {
-              "version": "2.6.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+              "version": "2.7.1",
+              "from": "commander@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
             },
             "glob": {
-              "version": "4.4.1",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+              "version": "4.5.3",
+              "from": "glob@>=4.3.4 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
-                "minimatch": {
+                "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6607,12 +6799,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -6621,8 +6813,328 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "pangyp": {
+          "version": "2.1.0",
+          "from": "pangyp@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.1.0.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.5 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.5 <3.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "1.0.0",
+              "from": "npmlog@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.0.3",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.3.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.0.2",
+                  "from": "gauge@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.0",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@>=2.51.0 <2.52.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "4.2.2",
+              "from": "semver@>=4.2.0 <4.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+            },
+            "tar": {
+              "version": "1.0.3",
+              "from": "tar@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                }
+              }
             }
           }
         }
@@ -6630,292 +7142,45 @@
     },
     "nodemon": {
       "version": "1.3.7",
-      "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.7.tgz",
+      "from": "nodemon@>=1.3.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.7.tgz",
       "dependencies": {
         "minimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "ps-tree": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
+          "from": "ps-tree@>=0.0.3 <0.1.0",
           "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
           "dependencies": {
             "event-stream": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
+              "from": "event-stream@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.2.8",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+                  "from": "optimist@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "touch": {
-          "version": "0.0.3",
-          "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-          "dependencies": {
-            "nopt": {
-              "version": "1.0.10",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "update-notifier": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
-          "dependencies": {
-            "configstore": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.5",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-                },
-                "js-yaml": {
-                  "version": "3.2.7",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
-                        },
-                        "sprintf-js": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "xdg-basedir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
-            },
-            "latest-version": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
-              "dependencies": {
-                "package-json": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
-                  "dependencies": {
-                    "got": {
-                      "version": "2.4.0",
-                      "from": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
-                      "dependencies": {
-                        "duplexify": {
-                          "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "1.0.33",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "infinity-agent": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
-                        },
-                        "is-stream": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                        },
-                        "prepend-http": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
-                        },
-                        "read-all-stream": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
-                        },
-                        "statuses": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-                        },
-                        "timed-out": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.0.tgz",
-                      "dependencies": {
-                        "rc": {
-                          "version": "0.6.0",
-                          "from": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.10",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                            },
-                            "strip-json-comments": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                            },
-                            "ini": {
-                              "version": "1.3.3",
-                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz"
-            },
-            "string-length": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 }
@@ -6925,93 +7190,230 @@
         }
       }
     },
+    "npmconf": {
+      "version": "2.1.1",
+      "from": "npmconf@2.1.1",
+      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+      "dependencies": {
+        "config-chain": {
+          "version": "1.1.8",
+          "from": "config-chain@>=1.1.8 <1.2.0",
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.3",
+              "from": "proto-list@>=1.2.1 <1.3.0",
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.1",
+          "from": "nopt@>=3.0.1 <3.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        },
+        "uid-number": {
+          "version": "0.0.5",
+          "from": "uid-number@0.0.5",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+        }
+      }
+    },
+    "object-assign": {
+      "version": "2.0.0",
+      "from": "object-assign@2.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+    },
+    "once": {
+      "version": "1.3.1",
+      "from": "once@1.3.1",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+      "dependencies": {
+        "wrappy": {
+          "version": "1.0.1",
+          "from": "wrappy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+        }
+      }
+    },
     "opn": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz",
+      "from": "opn@1.0.1",
       "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+    },
+    "osenv": {
+      "version": "0.1.0",
+      "from": "osenv@0.1.0",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
     },
     "prompt": {
       "version": "0.2.14",
-      "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "from": "prompt@>=0.2.14 <0.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
       "dependencies": {
         "pkginfo": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+          "from": "pkginfo@>=0.0.0 <1.0.0",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
         },
         "revalidator": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+          "from": "revalidator@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
         },
         "utile": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+          "from": "utile@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.9 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "deep-equal": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+              "from": "deep-equal@*",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
             },
             "i": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/i/-/i-0.3.2.tgz",
+              "from": "i@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "ncp": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+              "from": "ncp@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+            },
+            "rimraf": {
+              "version": "2.3.2",
+              "from": "rimraf@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },
         "winston": {
           "version": "0.8.3",
-          "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "from": "winston@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "colors": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+              "from": "colors@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "from": "cycle@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
@@ -7020,40 +7422,40 @@
     },
     "read": {
       "version": "1.0.5",
-      "from": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+      "from": "read@1.0.5",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz"
+    },
+    "replacestream": {
+      "version": "2.1.0",
+      "from": "replacestream@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.1.0.tgz"
+    },
+    "request-progress": {
+      "version": "0.3.1",
+      "from": "request-progress@0.3.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
       "dependencies": {
-        "mute-stream": {
-          "version": "0.0.4",
-          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+        "throttleit": {
+          "version": "0.0.2",
+          "from": "throttleit@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
         }
       }
     },
-    "replace-ext": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-    },
-    "replacestream": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz"
-    },
     "requirejs": {
       "version": "2.1.16",
-      "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz",
+      "from": "requirejs@>=2.1.16 <3.0.0",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz"
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "from": "rimraf@2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "semver": {
-      "version": "4.3.1",
-      "from": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz"
+      "version": "4.3.3",
+      "from": "semver@>=4.3.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
     },
     "shelljs": {
       "version": "0.3.0",
@@ -7130,6 +7532,11 @@
               "version": "1.1.2",
               "from": "component-emitter@1.1.2",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "benchmark": {
               "version": "1.0.0",
@@ -7275,7 +7682,14 @@
             "has-binary": {
               "version": "0.1.6",
               "from": "has-binary@0.1.6",
-              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
             },
             "parseuri": {
               "version": "0.0.2",
@@ -7344,6 +7758,11 @@
                   "version": "1.1.2",
                   "from": "component-emitter@1.1.2",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "benchmark": {
                   "version": "1.0.0",
@@ -7422,19 +7841,55 @@
         }
       }
     },
+    "strip-ansi": {
+      "version": "2.0.1",
+      "from": "strip-ansi@2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        }
+      }
+    },
     "through": {
       "version": "2.3.6",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+      "from": "through@2.3.6",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
     },
+    "timers-ext": {
+      "version": "0.1.0",
+      "from": "timers-ext@0.1.0",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
+    },
+    "touch": {
+      "version": "0.0.3",
+      "from": "touch@0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
     "uglify-js": {
-      "version": "2.4.17",
+      "version": "2.4.19",
       "from": "uglify-js@>=2.4.17 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.17.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
+          "from": "async@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
@@ -7450,9 +7905,31 @@
           }
         },
         "yargs": {
-          "version": "1.3.3",
-          "from": "yargs@>=1.3.3 <1.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+          "version": "3.5.4",
+          "from": "yargs@>=3.5.4 <3.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "1.0.2",
+              "from": "camelcase@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+            },
+            "decamelize": {
+              "version": "1.0.0",
+              "from": "decamelize@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "from": "window-size@0.1.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
@@ -7461,9 +7938,169 @@
         }
       }
     },
+    "update-notifier": {
+      "version": "0.3.1",
+      "from": "update-notifier@0.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
+      "dependencies": {
+        "is-npm": {
+          "version": "1.0.0",
+          "from": "is-npm@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+        },
+        "latest-version": {
+          "version": "1.0.0",
+          "from": "latest-version@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+          "dependencies": {
+            "package-json": {
+              "version": "1.1.0",
+              "from": "package-json@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+              "dependencies": {
+                "got": {
+                  "version": "2.5.0",
+                  "from": "got@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/got/-/got-2.5.0.tgz",
+                  "dependencies": {
+                    "duplexify": {
+                      "version": "3.2.0",
+                      "from": "duplexify@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
+                      "dependencies": {
+                        "end-of-stream": {
+                          "version": "1.0.0",
+                          "from": "end-of-stream@1.0.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.1",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "infinity-agent": {
+                      "version": "1.0.2",
+                      "from": "infinity-agent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
+                    },
+                    "is-stream": {
+                      "version": "1.0.1",
+                      "from": "is-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                    },
+                    "lowercase-keys": {
+                      "version": "1.0.0",
+                      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                    },
+                    "prepend-http": {
+                      "version": "1.0.1",
+                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                    },
+                    "read-all-stream": {
+                      "version": "1.0.2",
+                      "from": "read-all-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    },
+                    "timed-out": {
+                      "version": "2.0.0",
+                      "from": "timed-out@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                    }
+                  }
+                },
+                "registry-url": {
+                  "version": "3.0.1",
+                  "from": "registry-url@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.1.tgz",
+                  "dependencies": {
+                    "rc": {
+                      "version": "0.6.0",
+                      "from": "rc@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.10",
+                          "from": "minimist@>=0.0.7 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "0.1.3",
+                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "semver-diff": {
+          "version": "2.0.0",
+          "from": "semver-diff@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz"
+        },
+        "string-length": {
+          "version": "1.0.0",
+          "from": "string-length@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz"
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "from": "user-home@1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
     "which": {
       "version": "1.0.9",
-      "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "from": "which@1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,56 +4,56 @@
   "dependencies": {
     "array-uniq": {
       "version": "1.0.2",
-      "from": "array-uniq@1.0.2",
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "autoprefixer": {
       "version": "5.1.0",
-      "from": "autoprefixer@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-5.1.0.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.1.7",
-          "from": "autoprefixer-core@>=5.1.0 <5.2.0",
+          "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.7.tgz",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.7.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.2.0",
-              "from": "browserslist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
             },
             "num2fraction": {
               "version": "1.0.1",
-              "from": "num2fraction@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
             },
             "caniuse-db": {
               "version": "1.0.30000081",
-              "from": "caniuse-db@>=1.0.30000078 <2.0.0",
+              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000081.tgz",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000081.tgz"
             }
           }
         },
         "postcss": {
           "version": "4.0.6",
-          "from": "postcss@>=4.0.2 <4.1.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "js-base64": {
               "version": "2.1.7",
-              "from": "js-base64@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
             }
           }
@@ -61,9 +61,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1.14",
-      "from": "aws-sdk@>=2.1.7 <3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.14.tgz",
+      "version": "2.1.18",
+      "from": "aws-sdk@>=2.1.18 <3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.18.tgz",
       "dependencies": {
         "xml2js": {
           "version": "0.2.6",
@@ -86,134 +86,124 @@
     },
     "bower": {
       "version": "1.3.12",
-      "from": "bower@>=1.3.12 <2.0.0",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
       "dependencies": {
         "abbrev": {
           "version": "1.0.5",
-          "from": "abbrev@>=1.0.4 <1.1.0",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
         },
         "archy": {
           "version": "0.0.2",
-          "from": "archy@0.0.2",
+          "from": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
         },
         "bower-config": {
           "version": "0.5.2",
-          "from": "bower-config@>=0.5.2 <0.6.0",
+          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "osenv@0.0.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
         },
         "bower-endpoint-parser": {
           "version": "0.2.2",
-          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
         },
         "bower-json": {
           "version": "0.4.0",
-          "from": "bower-json@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "intersect": {
               "version": "0.0.3",
-              "from": "intersect@>=0.0.3 <0.1.0",
+              "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "bower-logger@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "bower-registry-client": {
           "version": "0.2.3",
-          "from": "bower-registry-client@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.8 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "lru-cache": {
               "version": "2.3.1",
-              "from": "lru-cache@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
             },
             "request": {
               "version": "2.51.0",
-              "from": "request@>=2.51.0 <2.52.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -221,32 +211,32 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.9",
-                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                         }
                       }
@@ -255,113 +245,113 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
+                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -370,187 +360,177 @@
             },
             "request-replay": {
               "version": "0.2.0",
-              "from": "request-replay@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
         },
         "cardinal": {
           "version": "0.4.0",
-          "from": "cardinal@0.4.0",
+          "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
           "dependencies": {
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.5.0",
-          "from": "chalk@0.5.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "chmodr": {
           "version": "0.1.0",
-          "from": "chmodr@0.1.0",
+          "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
         },
         "decompress-zip": {
           "version": "0.0.8",
-          "from": "decompress-zip@0.0.8",
+          "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
           "dependencies": {
             "mkpath": {
               "version": "0.1.0",
-              "from": "mkpath@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
             },
             "binary": {
               "version": "0.3.0",
-              "from": "binary@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "dependencies": {
                 "chainsaw": {
                   "version": "0.1.0",
-                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
                 },
                 "buffers": {
                   "version": "0.1.1",
-                  "from": "buffers@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
             "touch": {
               "version": "0.0.2",
-              "from": "touch@0.0.2",
+              "from": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "nopt@>=1.0.10 <1.1.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.8 <1.2.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
             }
           }
         },
         "fstream": {
           "version": "1.0.4",
-          "from": "fstream@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz"
         },
         "fstream-ignore": {
           "version": "1.0.2",
-          "from": "fstream-ignore@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
           "dependencies": {
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -561,34 +541,29 @@
         },
         "glob": {
           "version": "4.0.6",
-          "from": "glob@>=4.0.2 <4.1.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -597,44 +572,44 @@
         },
         "graceful-fs": {
           "version": "3.0.5",
-          "from": "graceful-fs@>=3.0.1 <3.1.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
         },
         "handlebars": {
           "version": "2.0.0",
-          "from": "handlebars@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -645,90 +620,90 @@
         },
         "inquirer": {
           "version": "0.7.1",
-          "from": "inquirer@0.7.1",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
           "dependencies": {
             "cli-color": {
               "version": "0.3.2",
-              "from": "cli-color@>=0.3.2 <0.4.0",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.6",
-                  "from": "es5-ext@>=0.10.2 <0.11.0",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "memoizee": {
                   "version": "0.3.8",
-                  "from": "memoizee@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                   "dependencies": {
                     "es6-weak-map": {
                       "version": "0.1.2",
-                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "es6-iterator@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                           "dependencies": {
                             "es6-symbol": {
                               "version": "2.0.1",
-                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                             }
                           }
                         },
                         "es6-symbol": {
                           "version": "0.1.1",
-                          "from": "es6-symbol@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                         }
                       }
                     },
                     "event-emitter": {
                       "version": "0.3.3",
-                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                     },
                     "lru-queue": {
                       "version": "0.1.0",
-                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                     },
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
                 },
                 "timers-ext": {
                   "version": "0.1.0",
-                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "dependencies": {
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
@@ -737,32 +712,32 @@
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@>=1.3.2 <2.0.0",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "mute-stream": {
               "version": "0.0.4",
-              "from": "mute-stream@0.0.4",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "readline2@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -771,214 +746,209 @@
             },
             "rx": {
               "version": "2.4.1",
-              "from": "rx@>=2.2.27 <3.0.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
-            },
-            "through": {
-              "version": "2.3.6",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "insight": {
           "version": "0.4.3",
-          "from": "insight@0.4.3",
+          "from": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.2.7",
-                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.1",
-                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.2.0",
-                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.2",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.0.0",
-                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.0.0",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "inquirer": {
               "version": "0.6.0",
-              "from": "inquirer@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
               "dependencies": {
                 "cli-color": {
                   "version": "0.3.2",
-                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.6",
-                      "from": "es5-ext@>=0.10.2 <0.11.0",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                         },
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "memoizee": {
                       "version": "0.3.8",
-                      "from": "memoizee@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.2",
-                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                          "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "0.1.3",
-                              "from": "es6-iterator@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                               "dependencies": {
                                 "es6-symbol": {
                                   "version": "2.0.1",
-                                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                                 }
                               }
                             },
                             "es6-symbol": {
                               "version": "0.1.1",
-                              "from": "es6-symbol@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                             }
                           }
                         },
                         "event-emitter": {
                           "version": "0.3.3",
-                          "from": "event-emitter@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                         },
                         "lru-queue": {
                           "version": "0.1.0",
-                          "from": "lru-queue@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                         },
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
@@ -987,27 +957,27 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
@@ -1016,46 +986,41 @@
                 },
                 "rx": {
                   "version": "2.4.1",
-                  "from": "rx@>=2.2.27 <3.0.0",
+                  "from": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.1.tgz"
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.3.4 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "lodash.debounce": {
               "version": "2.4.1",
-              "from": "lodash.debounce@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
               "dependencies": {
                 "lodash.isfunction": {
                   "version": "2.4.1",
-                  "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                 },
                 "lodash.isobject": {
                   "version": "2.4.1",
-                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash.now": {
                   "version": "2.4.1",
-                  "from": "lodash.now@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     }
                   }
@@ -1064,34 +1029,34 @@
             },
             "object-assign": {
               "version": "1.0.0",
-              "from": "object-assign@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             },
             "os-name": {
               "version": "1.0.3",
-              "from": "os-name@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
               "dependencies": {
                 "osx-release": {
                   "version": "1.0.0",
-                  "from": "osx-release@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz"
                 },
                 "win-release": {
                   "version": "1.0.0",
-                  "from": "win-release@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
                 }
               }
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.1 <0.13.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
@@ -1100,107 +1065,97 @@
         },
         "is-root": {
           "version": "1.0.0",
-          "from": "is-root@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
         },
         "junk": {
           "version": "1.0.1",
-          "from": "junk@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
         },
         "lockfile": {
           "version": "1.0.0",
-          "from": "lockfile@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@>=2.5.0 <2.6.0",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.0.0 <1.0.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "mout": {
           "version": "0.9.1",
-          "from": "mout@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
         },
         "nopt": {
           "version": "3.0.1",
-          "from": "nopt@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
         },
         "osenv": {
           "version": "0.1.0",
-          "from": "osenv@0.1.0",
+          "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
         },
         "p-throttler": {
           "version": "0.1.0",
-          "from": "p-throttler@0.1.0",
+          "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@>=0.9.2 <0.10.0",
+              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "from": "promptly@0.2.0",
+          "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz"
         },
         "q": {
           "version": "1.0.1",
-          "from": "q@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
         },
         "request": {
           "version": "2.42.0",
-          "from": "request@>=2.42.0 <2.43.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -1208,257 +1163,247 @@
             },
             "caseless": {
               "version": "0.6.0",
-              "from": "caseless@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "1.0.2",
-              "from": "mime-types@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.4.0",
-              "from": "oauth-sign@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
             },
             "hawk": {
               "version": "1.1.1",
-              "from": "hawk@1.1.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             }
           }
         },
         "request-progress": {
           "version": "0.3.0",
-          "from": "request-progress@0.3.0",
+          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "retry": {
           "version": "0.6.0",
-          "from": "retry@0.6.0",
+          "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
         },
         "semver": {
           "version": "2.3.2",
-          "from": "semver@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "shell-quote": {
           "version": "1.4.2",
-          "from": "shell-quote@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "array-filter": {
               "version": "0.0.1",
-              "from": "array-filter@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
-              "from": "array-reduce@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
             "array-map": {
               "version": "0.0.0",
-              "from": "array-map@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             }
           }
         },
         "stringify-object": {
           "version": "1.0.0",
-          "from": "stringify-object@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz"
         },
         "tar-fs": {
           "version": "0.5.2",
-          "from": "tar-fs@0.5.2",
+          "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
           "dependencies": {
             "pump": {
               "version": "0.3.5",
-              "from": "pump@>=0.3.5 <0.4.0",
+              "from": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.2.0",
-                  "from": "once@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
                 }
               }
             },
             "tar-stream": {
               "version": "0.4.7",
-              "from": "tar-stream@>=0.4.6 <0.5.0",
+              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
@@ -1467,139 +1412,134 @@
         },
         "tmp": {
           "version": "0.0.23",
-          "from": "tmp@0.0.23",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
         },
         "update-notifier": {
           "version": "0.2.0",
-          "from": "update-notifier@0.2.0",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
           "dependencies": {
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.2.7",
-                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.1",
-                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.2.0",
-                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.2",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.0.0",
-                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.0.0",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "latest-version": {
               "version": "0.2.0",
-              "from": "latest-version@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
               "dependencies": {
                 "package-json": {
                   "version": "0.2.0",
-                  "from": "package-json@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
                   "dependencies": {
                     "got": {
                       "version": "0.3.0",
-                      "from": "got@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
                       "dependencies": {
                         "object-assign": {
                           "version": "0.3.1",
-                          "from": "object-assign@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
                         }
                       }
                     },
                     "registry-url": {
                       "version": "0.1.1",
-                      "from": "registry-url@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
                       "dependencies": {
                         "npmconf": {
                           "version": "2.1.1",
-                          "from": "npmconf@>=2.0.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
                           "dependencies": {
                             "config-chain": {
                               "version": "1.1.8",
-                              "from": "config-chain@>=1.1.8 <1.2.0",
+                              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                               "dependencies": {
                                 "proto-list": {
                                   "version": "1.2.3",
-                                  "from": "proto-list@>=1.2.1 <1.3.0",
+                                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                                 }
                               }
                             },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
                             "ini": {
                               "version": "1.3.3",
-                              "from": "ini@>=1.2.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                             },
                             "once": {
                               "version": "1.3.1",
-                              "from": "once@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "uid-number": {
                               "version": "0.0.5",
-                              "from": "uid-number@0.0.5",
+                              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                             }
                           }
@@ -1612,22 +1552,22 @@
             },
             "semver-diff": {
               "version": "0.1.0",
-              "from": "semver-diff@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz"
             },
             "string-length": {
               "version": "0.1.2",
-              "from": "string-length@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "0.2.2",
-                  "from": "strip-ansi@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.1.0",
-                      "from": "ansi-regex@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz"
                     }
                   }
@@ -1639,9 +1579,9 @@
       }
     },
     "browser-sync": {
-      "version": "2.2.1",
-      "from": "browser-sync@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.2.1.tgz",
+      "version": "2.4.0",
+      "from": "browser-sync@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.4.0.tgz",
       "dependencies": {
         "async-each-series": {
           "version": "0.1.1",
@@ -1654,29 +1594,29 @@
           "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-1.0.2.tgz"
         },
         "browser-sync-ui": {
-          "version": "0.4.9",
-          "from": "browser-sync-ui@>=0.4.9 <0.5.0",
-          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.4.9.tgz",
+          "version": "0.4.11",
+          "from": "browser-sync-ui@>=0.4.11 <0.5.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.4.11.tgz",
           "dependencies": {
             "angular": {
-              "version": "1.3.14",
+              "version": "1.3.15",
               "from": "angular@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.14.tgz"
+              "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.15.tgz"
             },
             "angular-route": {
-              "version": "1.3.14",
+              "version": "1.3.15",
               "from": "angular-route@>=1.3.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.3.14.tgz"
+              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.3.15.tgz"
             },
             "angular-sanitize": {
-              "version": "1.3.14",
+              "version": "1.3.15",
               "from": "angular-sanitize@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.14.tgz"
+              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.15.tgz"
             },
             "angular-touch": {
-              "version": "1.3.14",
+              "version": "1.3.15",
               "from": "angular-touch@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.3.14.tgz"
+              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.3.15.tgz"
             },
             "connect-history-api-fallback": {
               "version": "0.0.5",
@@ -1744,26 +1684,26 @@
           }
         },
         "connect": {
-          "version": "3.3.4",
-          "from": "connect@>=3.3.3 <4.0.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-3.3.4.tgz",
+          "version": "3.3.5",
+          "from": "connect@>=3.3.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.3.5.tgz",
           "dependencies": {
             "debug": {
-              "version": "2.1.1",
-              "from": "debug@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "version": "2.1.3",
+              "from": "debug@>=2.1.3 <2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                 }
               }
             },
             "finalhandler": {
-              "version": "0.3.3",
-              "from": "finalhandler@0.3.3",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
+              "version": "0.3.4",
+              "from": "finalhandler@0.3.4",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
@@ -1802,9 +1742,9 @@
           "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz"
         },
         "easy-extender": {
-          "version": "2.2.0",
-          "from": "easy-extender@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.2.0.tgz",
+          "version": "2.3.0",
+          "from": "easy-extender@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
@@ -1857,7 +1797,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1869,7 +1809,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1882,9 +1822,9 @@
                   }
                 },
                 "object-path": {
-                  "version": "0.9.0",
+                  "version": "0.9.1",
                   "from": "object-path@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.0.tgz"
+                  "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.1.tgz"
                 }
               }
             }
@@ -1906,9 +1846,9 @@
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
             },
             "http-proxy": {
-              "version": "1.8.1",
+              "version": "1.9.0",
               "from": "http-proxy@>=1.8.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.0.tgz",
               "dependencies": {
                 "eventemitter3": {
                   "version": "0.1.6",
@@ -1949,11 +1889,6 @@
                   "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    },
                     "repeating": {
                       "version": "1.1.2",
                       "from": "repeating@>=1.1.0 <2.0.0",
@@ -1983,14 +1918,14 @@
           }
         },
         "glob-watcher": {
-          "version": "0.0.7",
-          "from": "glob-watcher@>=0.0.7 <0.0.8",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.7.tgz"
+          "version": "0.0.8",
+          "from": "glob-watcher@>=0.0.8 <0.0.9",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz"
         },
         "immutable": {
-          "version": "3.6.2",
-          "from": "immutable@>=3.4.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.6.2.tgz"
+          "version": "3.6.4",
+          "from": "immutable@>=3.6.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.6.4.tgz"
         },
         "localtunnel": {
           "version": "1.5.0",
@@ -2048,13 +1983,13 @@
           }
         },
         "lodash": {
-          "version": "3.3.1",
+          "version": "3.5.0",
           "from": "lodash@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
         },
         "meow": {
           "version": "3.1.0",
-          "from": "meow@>=3.0.0 <4.0.0",
+          "from": "meow@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "dependencies": {
             "camelcase-keys": {
@@ -2079,11 +2014,6 @@
               "from": "indent-string@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
                 "repeating": {
                   "version": "1.1.2",
                   "from": "repeating@>=1.1.0 <2.0.0",
@@ -2123,9 +2053,9 @@
           "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-2.0.1.tgz",
           "dependencies": {
             "minimatch": {
-              "version": "2.0.1",
+              "version": "2.0.4",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -2149,14 +2079,14 @@
           }
         },
         "serve-index": {
-          "version": "1.6.2",
-          "from": "serve-index@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.2.tgz",
+          "version": "1.6.3",
+          "from": "serve-index@>=1.6.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.3.tgz",
           "dependencies": {
             "accepts": {
-              "version": "1.2.4",
-              "from": "accepts@>=1.2.4 <1.3.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz",
+              "version": "1.2.5",
+              "from": "accepts@>=1.2.5 <1.3.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
               "dependencies": {
                 "negotiator": {
                   "version": "0.5.1",
@@ -2171,27 +2101,27 @@
               "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
             },
             "debug": {
-              "version": "2.1.1",
-              "from": "debug@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "version": "2.1.3",
+              "from": "debug@>=2.1.3 <2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                 }
               }
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
               "from": "http-errors@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "statuses": {
                   "version": "1.2.1",
                   "from": "statuses@>=1.0.0 <2.0.0",
@@ -2200,14 +2130,14 @@
               }
             },
             "mime-types": {
-              "version": "2.0.9",
-              "from": "mime-types@>=2.0.9 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+              "version": "2.0.10",
+              "from": "mime-types@>=2.0.10 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                  "version": "1.8.0",
+                  "from": "mime-db@>=1.8.0 <1.9.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             },
@@ -2219,9 +2149,9 @@
           }
         },
         "serve-static": {
-          "version": "1.9.1",
+          "version": "1.9.2",
           "from": "serve-static@>=1.9.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz",
           "dependencies": {
             "escape-html": {
               "version": "1.0.1",
@@ -2234,21 +2164,14 @@
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "send": {
-              "version": "0.12.1",
-              "from": "send@0.12.1",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.12.1.tgz",
+              "version": "0.12.2",
+              "from": "send@0.12.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
               "dependencies": {
                 "debug": {
-                  "version": "2.1.1",
-                  "from": "debug@>=2.1.1 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
+                  "version": "2.1.3",
+                  "from": "debug@>=2.1.3 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz"
                 },
                 "depd": {
                   "version": "1.0.0",
@@ -2308,390 +2231,6 @@
             }
           }
         },
-        "socket.io": {
-          "version": "1.3.4",
-          "from": "socket.io@>=1.3.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.4.tgz",
-          "dependencies": {
-            "engine.io": {
-              "version": "1.5.1",
-              "from": "engine.io@1.5.1",
-              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "1.0.3",
-                  "from": "debug@1.0.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "ws": {
-                  "version": "0.5.0",
-                  "from": "ws@0.5.0",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
-                  "dependencies": {
-                    "nan": {
-                      "version": "1.4.3",
-                      "from": "nan@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
-                    },
-                    "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                    },
-                    "ultron": {
-                      "version": "1.0.1",
-                      "from": "ultron@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
-                    }
-                  }
-                },
-                "base64id": {
-                  "version": "0.1.0",
-                  "from": "base64id@0.1.0",
-                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.3",
-              "from": "socket.io-parser@2.2.3",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.3.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "json3": {
-                  "version": "3.2.6",
-                  "from": "json3@3.2.6",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "benchmark": {
-                  "version": "1.0.0",
-                  "from": "benchmark@1.0.0",
-                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                }
-              }
-            },
-            "socket.io-client": {
-              "version": "1.3.4",
-              "from": "socket.io-client@1.3.4",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.4.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "engine.io-client": {
-                  "version": "1.5.1",
-                  "from": "engine.io-client@1.5.1",
-                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
-                  "dependencies": {
-                    "has-cors": {
-                      "version": "1.0.3",
-                      "from": "has-cors@1.0.3",
-                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
-                      "dependencies": {
-                        "global": {
-                          "version": "2.0.1",
-                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "0.4.31",
-                      "from": "ws@0.4.31",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                      "dependencies": {
-                        "commander": {
-                          "version": "0.6.1",
-                          "from": "commander@>=0.6.1 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                        },
-                        "nan": {
-                          "version": "0.3.2",
-                          "from": "nan@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
-                        },
-                        "tinycolor": {
-                          "version": "0.0.1",
-                          "from": "tinycolor@>=0.0.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                        },
-                        "options": {
-                          "version": "0.0.6",
-                          "from": "options@>=0.0.5",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                        }
-                      }
-                    },
-                    "xmlhttprequest": {
-                      "version": "1.5.0",
-                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
-                      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
-                    },
-                    "debug": {
-                      "version": "1.0.4",
-                      "from": "debug@1.0.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.6.2",
-                          "from": "ms@0.6.2",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                        }
-                      }
-                    },
-                    "parseuri": {
-                      "version": "0.0.4",
-                      "from": "parseuri@0.0.4",
-                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parsejson": {
-                      "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
-                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
-                    },
-                    "parseqs": {
-                      "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
-                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
-                    },
-                    "component-inherit": {
-                      "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
-                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
-                    },
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "from": "better-assert@1.0.2",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@1.0.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "from": "object-component@0.0.3",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
-                },
-                "has-binary": {
-                  "version": "0.1.6",
-                  "from": "has-binary@0.1.6",
-                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    }
-                  }
-                },
-                "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                },
-                "parseuri": {
-                  "version": "0.0.2",
-                  "from": "parseuri@0.0.2",
-                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
-                  "dependencies": {
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@1.0.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "to-array": {
-                  "version": "0.1.3",
-                  "from": "to-array@0.1.3",
-                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
-                },
-                "backo2": {
-                  "version": "1.0.2",
-                  "from": "backo2@1.0.2",
-                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
-                }
-              }
-            },
-            "socket.io-adapter": {
-              "version": "0.3.1",
-              "from": "socket.io-adapter@0.3.1",
-              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "1.0.2",
-                  "from": "debug@1.0.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "socket.io-parser": {
-                  "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@0.7.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    },
-                    "json3": {
-                      "version": "3.2.6",
-                      "from": "json3@3.2.6",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                    },
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
-                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0",
-                      "from": "benchmark@1.0.0",
-                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                    }
-                  }
-                },
-                "object-keys": {
-                  "version": "1.0.1",
-                  "from": "object-keys@1.0.1",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.3",
-              "from": "has-binary-data@0.1.3",
-              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz"
-            },
-            "debug": {
-              "version": "2.1.0",
-              "from": "debug@2.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                }
-              }
-            },
-            "engine.io-parser": {
-              "version": "1.2.1",
-              "from": "engine.io-parser@1.2.1",
-              "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
-              "dependencies": {
-                "after": {
-                  "version": "0.8.1",
-                  "from": "after@0.8.1",
-                  "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                },
-                "arraybuffer.slice": {
-                  "version": "0.0.6",
-                  "from": "arraybuffer.slice@0.0.6",
-                  "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                },
-                "base64-arraybuffer": {
-                  "version": "0.1.2",
-                  "from": "base64-arraybuffer@0.1.2",
-                  "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                },
-                "blob": {
-                  "version": "0.0.2",
-                  "from": "blob@0.0.2",
-                  "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                },
-                "has-binary": {
-                  "version": "0.1.5",
-                  "from": "has-binary@0.1.5",
-                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    }
-                  }
-                },
-                "utf8": {
-                  "version": "2.0.0",
-                  "from": "utf8@2.0.0",
-                  "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
         "ua-parser-js": {
           "version": "0.7.3",
           "from": "ua-parser-js@>=0.7.3 <0.8.0",
@@ -2701,66 +2240,56 @@
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "browserify@>=9.0.3 <10.0.0",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "JSONStream@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "jsonparse@0.0.5",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-            },
-            "through": {
-              "version": "2.3.6",
-              "from": "through@>=2.2.7 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
           "version": "4.0.0",
-          "from": "browser-pack@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.0.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -2769,134 +2298,134 @@
             },
             "umd": {
               "version": "3.0.0",
-              "from": "umd@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
             }
           }
         },
         "browser-resolve": {
           "version": "1.7.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.2.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.5",
-              "from": "pako@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.0.3",
-          "from": "buffer@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.4",
-              "from": "ieee754@>=1.1.4 <2.0.0",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "is-array@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "commondir@0.0.1",
+          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.7",
-          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.9.13",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
           "dependencies": {
             "browserify-aes": {
               "version": "1.0.0",
-              "from": "browserify-aes@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
               "version": "2.8.0",
-              "from": "browserify-sign@2.8.0",
+              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "browserify-rsa": {
                   "version": "1.1.1",
-                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "parse-asn1": {
                   "version": "2.0.0",
-                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
                     },
                     "asn1.js-rfc3280": {
                       "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                     },
                     "pemstrip": {
                       "version": "0.0.1",
-                      "from": "pemstrip@0.0.1",
+                      "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
@@ -2905,66 +2434,66 @@
             },
             "create-ecdh": {
               "version": "2.0.0",
-              "from": "create-ecdh@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz"
             },
             "create-hash": {
               "version": "1.1.0",
-              "from": "create-hash@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "1.0.0",
-                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
               "version": "3.0.1",
-              "from": "diffie-hellman@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "miller-rabin": {
                   "version": "1.1.5",
-                  "from": "miller-rabin@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz"
                 }
               }
             },
             "pbkdf2-compat": {
               "version": "3.0.2",
-              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
             },
             "public-encrypt": {
               "version": "2.0.0",
-              "from": "public-encrypt@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
               "dependencies": {
                 "browserify-rsa": {
                   "version": "2.0.0",
-                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                 },
                 "parse-asn1": {
                   "version": "3.0.0",
-                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
@@ -2975,27 +2504,27 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "randombytes@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             },
             "bn.js": {
               "version": "1.3.0",
-              "from": "bn.js@1.3.0",
+              "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
             },
             "brorand": {
               "version": "1.0.5",
-              "from": "brorand@1.0.5",
+              "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
             },
             "elliptic": {
               "version": "1.0.1",
-              "from": "elliptic@1.0.1",
+              "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
               "dependencies": {
                 "hash.js": {
                   "version": "1.0.2",
-                  "from": "hash.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                 }
               }
@@ -3004,54 +2533,49 @@
         },
         "deep-equal": {
           "version": "1.0.0",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.5",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.8.4",
-              "from": "JSONStream@>=0.8.4 <0.9.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -3062,49 +2586,49 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.4.1",
-          "from": "glob@>=4.0.5 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3113,12 +2637,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -3127,56 +2651,56 @@
         },
         "has": {
           "version": "1.0.0",
-          "from": "has@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/has/-/has-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "insert-module-globals": {
           "version": "6.2.0",
-          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "lexical-scope": {
               "version": "1.1.0",
-              "from": "lexical-scope@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "1.1.0",
-                  "from": "astw@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "3001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
@@ -3185,24 +2709,24 @@
             },
             "process": {
               "version": "0.6.0",
-              "from": "process@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             }
           }
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.1",
-              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 }
               }
@@ -3211,101 +2735,96 @@
         },
         "module-deps": {
           "version": "3.7.2",
-          "from": "module-deps@>=3.7.0 <4.0.0",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "detective": {
               "version": "4.0.0",
-              "from": "detective@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.1",
-                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.4",
-                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "optionator@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
                           "version": "1.1.1",
-                          "from": "prelude-ls@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "deep-is@>=0.1.2 <0.2.0",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "type-check@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "levn@>=0.2.5 <0.3.0",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -3316,34 +2835,34 @@
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
@@ -3352,41 +2871,41 @@
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "subarg@0.0.1",
+              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -3395,83 +2914,83 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@>=0.11.15 <0.12.0",
+              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.0",
-          "from": "process@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@>=1.2.3 <1.3.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.5",
-          "from": "resolve@>=1.1.4 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "shallow-copy@0.0.1",
+          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "shasum@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
@@ -3480,113 +2999,108 @@
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
         },
         "syntax-error": {
           "version": "1.1.2",
-          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.9.0",
-              "from": "acorn@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
           "version": "1.4.0",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.2",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-        },
-        "indexof": {
-          "version": "0.0.1",
-          "from": "indexof@0.0.1",
-          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
         },
         "sha.js": {
           "version": "2.3.6",
-          "from": "sha.js@2.3.6",
+          "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
         },
         "combine-source-map": {
           "version": "0.3.0",
-          "from": "combine-source-map@0.3.0",
+          "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
           "dependencies": {
             "inline-source-map": {
               "version": "0.3.1",
-              "from": "inline-source-map@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.3.0",
-                  "from": "source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -3595,12 +3109,12 @@
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.31 <0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -3611,59 +3125,54 @@
     },
     "chalk": {
       "version": "1.0.0",
-      "from": "chalk@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "2.0.1",
-          "from": "ansi-styles@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "has-ansi": {
           "version": "1.0.3",
-          "from": "has-ansi@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             }
           }
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             }
           }
         },
         "supports-color": {
           "version": "1.3.0",
-          "from": "supports-color@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.0.tgz"
         }
       }
     },
     "chokidar": {
-      "version": "1.0.0-rc3",
-      "from": "chokidar@>=1.0.0-rc2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc3.tgz",
+      "version": "1.0.0-rc4",
+      "from": "chokidar@>=1.0.0-rc4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc4.tgz",
       "dependencies": {
         "anymatch": {
           "version": "1.1.0",
@@ -3695,14 +3204,14 @@
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
         },
         "glob-parent": {
-          "version": "1.0.0",
+          "version": "1.2.0",
           "from": "glob-parent@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
           "dependencies": {
             "is-glob": {
-              "version": "0.3.0",
-              "from": "is-glob@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-0.3.0.tgz"
+              "version": "1.1.3",
+              "from": "is-glob@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             }
           }
         },
@@ -3755,20 +3264,10 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -3790,54 +3289,54 @@
     },
     "colors": {
       "version": "1.0.3",
-      "from": "colors@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
     "convert-source-map": {
       "version": "0.3.5",
-      "from": "convert-source-map@0.3.5",
+      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
     },
     "dateformat": {
       "version": "1.0.11",
-      "from": "dateformat@1.0.11",
+      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
       "dependencies": {
         "meow": {
           "version": "3.1.0",
-          "from": "meow@*",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.0.2",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.0",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                 }
               }
             },
             "indent-string": {
               "version": "1.2.1",
-              "from": "indent-string@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "1.1.2",
-                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.0",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                     }
                   }
@@ -3846,7 +3345,7 @@
             },
             "object-assign": {
               "version": "2.0.0",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
             }
           }
@@ -3855,86 +3354,81 @@
     },
     "deep-extend": {
       "version": "0.2.11",
-      "from": "deep-extend@0.2.11",
+      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
     },
     "del": {
       "version": "1.1.1",
-      "from": "del@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.0",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
             }
           }
         },
         "globby": {
           "version": "1.2.0",
-          "from": "globby@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
           "dependencies": {
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "glob": {
               "version": "4.4.1",
-              "from": "glob@>=4.4.0 <5.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -3943,12 +3437,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3959,22 +3453,22 @@
         },
         "is-path-cwd": {
           "version": "1.0.0",
-          "from": "is-path-cwd@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
         },
         "is-path-in-cwd": {
           "version": "1.0.0",
-          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
           "dependencies": {
             "is-path-inside": {
               "version": "1.0.0",
-              "from": "is-path-inside@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
               "dependencies": {
                 "path-is-inside": {
                   "version": "1.0.1",
-                  "from": "path-is-inside@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
                 }
               }
@@ -3983,40 +3477,30 @@
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         }
       }
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "duplexer2@0.0.2",
+      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -4024,17 +3508,17 @@
     },
     "end-of-stream": {
       "version": "1.0.0",
-      "from": "end-of-stream@1.0.0",
+      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
       "dependencies": {
         "once": {
           "version": "1.3.1",
-          "from": "once@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
@@ -4043,59 +3527,54 @@
     },
     "es6-promise": {
       "version": "2.0.1",
-      "from": "es6-promise@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz"
     },
     "esprima": {
       "version": "1.0.4",
-      "from": "esprima@1.0.4",
+      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
     },
     "findup-sync": {
       "version": "0.2.1",
-      "from": "findup-sync@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "dependencies": {
         "glob": {
           "version": "4.3.5",
-          "from": "glob@>=4.3.0 <4.4.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -4104,12 +3583,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -4119,14 +3598,14 @@
       }
     },
     "fs-extra": {
-      "version": "0.16.3",
-      "from": "fs-extra@>=0.16.3 <0.17.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.3.tgz",
+      "version": "0.16.5",
+      "from": "fs-extra@>=0.16.5 <0.17.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.5",
+          "version": "3.0.6",
           "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
         },
         "jsonfile": {
           "version": "2.0.0",
@@ -4137,49 +3616,49 @@
     },
     "gaze": {
       "version": "0.5.1",
-      "from": "gaze@0.5.1",
+      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
       "dependencies": {
         "globule": {
           "version": "0.1.0",
-          "from": "globule@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "1.0.1",
-              "from": "lodash@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
             },
             "glob": {
               "version": "3.1.21",
-              "from": "glob@>=3.1.21 <3.2.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.0",
-                  "from": "inherits@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -4190,47 +3669,47 @@
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@4.0.1",
+      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "gh-pages": {
       "version": "0.2.0",
-      "from": "gh-pages@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.2.0.tgz",
       "dependencies": {
         "q": {
           "version": "1.0.1",
-          "from": "q@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
         },
         "q-io": {
           "version": "1.11.6",
-          "from": "q-io@>=1.11.0 <1.12.0",
+          "from": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
           "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
           "dependencies": {
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "url2": {
               "version": "0.0.0",
-              "from": "url2@>=0.0.0 <0.0.1",
+              "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
             },
             "mimeparse": {
               "version": "0.1.4",
-              "from": "mimeparse@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
             },
             "collections": {
               "version": "0.2.2",
-              "from": "collections@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
               "dependencies": {
                 "weak-map": {
                   "version": "1.0.0",
-                  "from": "weak-map@1.0.0",
+                  "from": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
                 }
               }
@@ -4239,64 +3718,59 @@
         },
         "graceful-fs": {
           "version": "2.0.1",
-          "from": "graceful-fs@2.0.1",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz"
         },
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
         },
         "wrench": {
           "version": "1.5.1",
-          "from": "wrench@1.5.1",
+          "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.1.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "glob": {
           "version": "4.0.6",
-          "from": "glob@>=4.0.2 <4.1.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.5",
-              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -4306,14 +3780,14 @@
       }
     },
     "glob-stream": {
-      "version": "4.0.1",
-      "from": "glob-stream@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.0.1.tgz",
+      "version": "5.0.0",
+      "from": "glob-stream@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.0.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "4.4.1",
-          "from": "glob@>=4.3.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
+          "version": "5.0.3",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -4326,11 +3800,6 @@
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.1",
@@ -4347,9 +3816,9 @@
           }
         },
         "minimatch": {
-          "version": "2.0.1",
+          "version": "2.0.4",
           "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
@@ -4371,9 +3840,28 @@
           }
         },
         "ordered-read-streams": {
-          "version": "0.1.0",
-          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+          "version": "0.2.0",
+          "from": "ordered-read-streams@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.2.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
         },
         "glob2base": {
           "version": "0.0.12",
@@ -4459,7 +3947,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "readable-stream@>=1.0.33 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -4467,20 +3955,10 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -4495,109 +3973,109 @@
     },
     "html-minifier": {
       "version": "0.7.0",
-      "from": "html-minifier@*",
+      "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.0.tgz",
       "dependencies": {
         "change-case": {
           "version": "2.2.0",
-          "from": "change-case@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/change-case/-/change-case-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.2.0.tgz",
           "dependencies": {
             "camel-case": {
               "version": "1.1.1",
-              "from": "camel-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
             },
             "constant-case": {
               "version": "1.1.0",
-              "from": "constant-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
             },
             "dot-case": {
               "version": "1.1.1",
-              "from": "dot-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
             },
             "is-lower-case": {
               "version": "1.1.1",
-              "from": "is-lower-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
             },
             "is-upper-case": {
               "version": "1.1.1",
-              "from": "is-upper-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
             },
             "lower-case": {
               "version": "1.1.2",
-              "from": "lower-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
             },
             "param-case": {
               "version": "1.1.1",
-              "from": "param-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
             },
             "pascal-case": {
               "version": "1.1.0",
-              "from": "pascal-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
             },
             "path-case": {
               "version": "1.1.1",
-              "from": "path-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
             },
             "sentence-case": {
               "version": "1.1.2",
-              "from": "sentence-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
             },
             "snake-case": {
               "version": "1.1.1",
-              "from": "snake-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
             },
             "swap-case": {
               "version": "1.1.0",
-              "from": "swap-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
             },
             "title-case": {
               "version": "1.1.0",
-              "from": "title-case@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
             },
             "upper-case": {
               "version": "1.1.2",
-              "from": "upper-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
             },
             "upper-case-first": {
               "version": "1.1.0",
-              "from": "upper-case-first@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.0.tgz"
             }
           }
         },
         "clean-css": {
           "version": "3.0.10",
-          "from": "clean-css@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.10.tgz",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.10.tgz",
           "dependencies": {
             "commander": {
               "version": "2.5.1",
-              "from": "commander@>=2.5.0 <2.6.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.43 <0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -4606,32 +4084,27 @@
         },
         "cli": {
           "version": "0.6.5",
-          "from": "cli@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -4640,119 +4113,129 @@
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@0.1.2",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             }
           }
         },
         "relateurl": {
           "version": "0.2.6",
-          "from": "relateurl@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
           "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
         }
       }
     },
+    "indexof": {
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+    },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@2.0.1",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "1.9.2",
-      "from": "jade@>=1.9.2 <2.0.0",
+      "from": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/jade/-/jade-1.9.2.tgz",
       "dependencies": {
         "character-parser": {
           "version": "1.2.1",
-          "from": "character-parser@1.2.1",
+          "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
         },
         "commander": {
           "version": "2.6.0",
-          "from": "commander@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "constantinople": {
           "version": "3.0.1",
-          "from": "constantinople@>=3.0.1 <3.1.0",
+          "from": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "transformers": {
           "version": "2.1.0",
-          "from": "transformers@2.1.0",
+          "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
           "dependencies": {
             "promise": {
               "version": "2.0.0",
-              "from": "promise@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
               "dependencies": {
                 "is-promise": {
                   "version": "1.0.1",
-                  "from": "is-promise@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                 }
               }
             },
             "css": {
               "version": "1.0.8",
-              "from": "css@>=1.0.8 <1.1.0",
+              "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
               "dependencies": {
                 "css-parse": {
                   "version": "1.0.4",
-                  "from": "css-parse@1.0.4",
+                  "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                 },
                 "css-stringify": {
                   "version": "1.0.5",
-                  "from": "css-stringify@1.0.5",
+                  "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.2.5",
-              "from": "uglify-js@>=2.2.5 <2.3.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -4763,29 +4246,29 @@
         },
         "void-elements": {
           "version": "2.0.1",
-          "from": "void-elements@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
         },
         "with": {
           "version": "4.0.1",
-          "from": "with@>=4.0.0 <4.1.0",
+          "from": "https://registry.npmjs.org/with/-/with-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/with/-/with-4.0.1.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.11.0",
-              "from": "acorn@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
             }
           }
         },
         "acorn-globals": {
           "version": "1.0.2",
-          "from": "acorn-globals@1.0.2",
+          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.11.0",
-              "from": "acorn@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
             }
           }
@@ -4794,96 +4277,18 @@
     },
     "jasmine-core": {
       "version": "2.2.0",
-      "from": "jasmine-core@>=2.1.3 <3.0.0",
+      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz"
     },
     "karma": {
-      "version": "0.12.31",
-      "from": "karma@>=0.12.31 <0.13.0",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
+      "version": "0.12.32",
+      "from": "karma@>=0.12.32 <0.13.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.32.tgz",
       "dependencies": {
         "di": {
           "version": "0.0.1",
           "from": "di@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
-        },
-        "socket.io": {
-          "version": "0.9.16",
-          "from": "socket.io@0.9.16",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
-          "dependencies": {
-            "socket.io-client": {
-              "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
-              "dependencies": {
-                "uglify-js": {
-                  "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
-                },
-                "ws": {
-                  "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
-                    },
-                    "nan": {
-                      "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
-                    },
-                    "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                    },
-                    "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                    }
-                  }
-                },
-                "xmlhttprequest": {
-                  "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
-                },
-                "active-x-obfuscator": {
-                  "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
-                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-                  "dependencies": {
-                    "zeparser": {
-                      "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
-                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "policyfile": {
-              "version": "0.0.4",
-              "from": "policyfile@0.0.4",
-              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
-            },
-            "base64id": {
-              "version": "0.1.0",
-              "from": "base64id@0.1.0",
-              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-            },
-            "redis": {
-              "version": "0.7.3",
-              "from": "redis@0.7.3",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
-            }
-          }
         },
         "chokidar": {
           "version": "0.12.6",
@@ -4905,20 +4310,10 @@
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -4948,11 +4343,6 @@
           "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "minimatch": {
               "version": "0.3.0",
               "from": "minimatch@>=0.3.0 <0.4.0",
@@ -4986,6 +4376,42 @@
               "version": "1.0.0",
               "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "expand-braces": {
+          "version": "0.1.1",
+          "from": "expand-braces@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.1.tgz",
+          "dependencies": {
+            "array-slice": {
+              "version": "0.2.2",
+              "from": "array-slice@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.2.tgz"
+            },
+            "braces": {
+              "version": "0.1.5",
+              "from": "braces@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+              "dependencies": {
+                "expand-range": {
+                  "version": "0.1.1",
+                  "from": "expand-range@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+                  "dependencies": {
+                    "is-number": {
+                      "version": "0.1.1",
+                      "from": "is-number@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
+                    },
+                    "repeat-string": {
+                      "version": "0.2.2",
+                      "from": "repeat-string@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
             }
           }
         },
@@ -5069,7 +4495,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <3.0.0",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mime": {
@@ -5097,20 +4523,10 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -5203,9 +4619,9 @@
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.7.0",
-                      "from": "mime-db@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                     }
                   }
                 }
@@ -5260,11 +4676,6 @@
                   "from": "http-errors@>=1.2.8 <1.3.0",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
                     "statuses": {
                       "version": "1.2.1",
                       "from": "statuses@>=1.0.0 <2.0.0",
@@ -5415,20 +4826,10 @@
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -5489,14 +4890,14 @@
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.0.9",
+                      "version": "2.0.10",
                       "from": "mime-types@>=2.0.4 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                         }
                       }
                     },
@@ -5583,14 +4984,14 @@
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.0.9",
+                  "version": "2.0.10",
                   "from": "mime-types@>=2.0.9 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.7.0",
-                      "from": "mime-db@>=1.7.0 <1.8.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                     }
                   }
                 }
@@ -5665,112 +5066,175 @@
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
+        },
+        "memoizee": {
+          "version": "0.3.8",
+          "from": "memoizee@>=0.3.8 <0.4.0",
+          "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "from": "d@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+            },
+            "es5-ext": {
+              "version": "0.10.6",
+              "from": "es5-ext@>=0.10.4 <0.11.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.2",
+              "from": "es6-weak-map@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "from": "es6-symbol@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                }
+              }
+            },
+            "event-emitter": {
+              "version": "0.3.3",
+              "from": "event-emitter@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+            },
+            "lru-queue": {
+              "version": "0.1.0",
+              "from": "lru-queue@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+            },
+            "next-tick": {
+              "version": "0.2.2",
+              "from": "next-tick@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+            },
+            "timers-ext": {
+              "version": "0.1.0",
+              "from": "timers-ext@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
+            }
+          }
         }
       }
     },
     "karma-browserify": {
       "version": "4.0.0",
-      "from": "karma-browserify@*",
+      "from": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.0.0.tgz",
       "dependencies": {
         "hat": {
           "version": "0.0.3",
-          "from": "hat@0.0.3",
+          "from": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz"
         },
         "js-string-escape": {
           "version": "1.0.0",
-          "from": "js-string-escape@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "os-shim": {
           "version": "0.1.2",
-          "from": "os-shim@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz"
         },
         "watchify": {
           "version": "2.4.0",
-          "from": "watchify@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/watchify/-/watchify-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.4.0.tgz",
           "dependencies": {
             "chokidar": {
               "version": "0.12.6",
-              "from": "chokidar@>=0.12.1 <0.13.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
               "dependencies": {
                 "readdirp": {
                   "version": "1.3.0",
-                  "from": "readdirp@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.12 <0.3.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -5778,17 +5242,17 @@
                 },
                 "async-each": {
                   "version": "0.1.6",
-                  "from": "async-each@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
                 },
                 "fsevents": {
                   "version": "0.3.5",
-                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "1.5.3",
-                      "from": "nan@>=1.5.0 <1.6.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
                     }
                   }
@@ -5797,39 +5261,29 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "3.0.0",
-                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
@@ -5840,52 +5294,52 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.7",
-      "from": "karma-chrome-launcher@>=0.1.7 <0.2.0",
+      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz"
     },
     "karma-coverage": {
       "version": "0.2.6",
-      "from": "karma-coverage@0.2.6",
+      "from": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.2.6.tgz",
       "dependencies": {
         "istanbul": {
           "version": "0.3.7",
-          "from": "istanbul@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.7.tgz",
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.7.tgz",
           "dependencies": {
             "esprima": {
               "version": "2.0.0",
-              "from": "esprima@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
             },
             "escodegen": {
               "version": "1.3.3",
-              "from": "escodegen@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.0.0",
-                  "from": "esutils@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                 },
                 "estraverse": {
                   "version": "1.5.1",
-                  "from": "estraverse@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                 },
                 "esprima": {
                   "version": "1.1.1",
-                  "from": "esprima@>=1.1.1 <1.2.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.33 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -5894,32 +5348,32 @@
             },
             "handlebars": {
               "version": "1.3.0",
-              "from": "handlebars@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -5930,88 +5384,76 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "3.0.1",
-              "from": "nopt@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
             },
             "fileset": {
               "version": "0.1.5",
-              "from": "fileset@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
                 }
               }
             },
-            "which": {
-              "version": "1.0.9",
-              "from": "which@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
-            },
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "supports-color": {
               "version": "1.2.1",
-              "from": "supports-color@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
             },
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             },
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@>=0.7.0 <0.8.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "js-yaml": {
               "version": "3.2.7",
-              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.1",
-                  "from": "argparse@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.2.0",
-                      "from": "lodash@>=3.2.0 <3.3.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.2",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                     }
                   }
@@ -6020,12 +5462,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -6034,59 +5476,59 @@
         },
         "ibrik": {
           "version": "1.1.1",
-          "from": "ibrik@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/ibrik/-/ibrik-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/ibrik/-/ibrik-1.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "coffee-script-redux": {
               "version": "2.0.0-beta8",
-              "from": "coffee-script-redux@2.0.0-beta8",
+              "from": "https://registry.npmjs.org/coffee-script-redux/-/coffee-script-redux-2.0.0-beta8.tgz",
               "resolved": "https://registry.npmjs.org/coffee-script-redux/-/coffee-script-redux-2.0.0-beta8.tgz",
               "dependencies": {
                 "StringScanner": {
                   "version": "0.0.3",
-                  "from": "StringScanner@>=0.0.3 <0.1.0",
+                  "from": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz"
                 },
                 "nopt": {
                   "version": "2.1.2",
-                  "from": "nopt@>=2.1.2 <2.2.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "esmangle": {
                   "version": "0.0.17",
-                  "from": "esmangle@>=0.0.8 <0.1.0",
+                  "from": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
                   "resolved": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
                   "dependencies": {
                     "escope": {
                       "version": "1.0.1",
-                      "from": "escope@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/escope/-/escope-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.1.tgz"
                     },
                     "estraverse": {
                       "version": "1.3.2",
-                      "from": "estraverse@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                     },
                     "esshorten": {
                       "version": "0.0.2",
-                      "from": "esshorten@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "1.2.0",
-                          "from": "estraverse@>=1.2.0 <1.3.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz"
                         }
                       }
@@ -6095,73 +5537,68 @@
                 },
                 "source-map": {
                   "version": "0.1.11",
-                  "from": "source-map@0.1.11",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.11.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "escodegen": {
                   "version": "0.0.28",
-                  "from": "escodegen@>=0.0.24 <0.1.0",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                   "dependencies": {
-                    "esprima": {
-                      "version": "1.0.4",
-                      "from": "esprima@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                    },
                     "estraverse": {
                       "version": "1.3.2",
-                      "from": "estraverse@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                     }
                   }
                 },
                 "cscodegen": {
                   "version": "0.1.0",
-                  "from": "../../../../../var/folders/nz/csl3swp54vd9ntllwqlhjc_w0000gn/T/npm-10855-49f3bd29/1425556562936-0.1502521219663322/73fd7202ac086c26f18c9d56f025b18b3c6f5383",
+                  "from": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
                   "resolved": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383"
                 }
               }
             },
             "istanbul": {
               "version": "0.2.16",
-              "from": "istanbul@>=0.2.4 <0.3.0",
+              "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
               "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.2.5",
-                  "from": "esprima@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "escodegen": {
                   "version": "1.3.3",
-                  "from": "escodegen@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "1.0.0",
-                      "from": "esutils@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                     },
                     "esprima": {
                       "version": "1.1.1",
-                      "from": "esprima@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.33 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -6170,32 +5607,32 @@
                 },
                 "handlebars": {
                   "version": "1.3.0",
-                  "from": "handlebars@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
                   "dependencies": {
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     },
                     "uglify-js": {
                       "version": "2.3.6",
-                      "from": "uglify-js@>=2.3.0 <2.4.0",
+                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "async@>=0.2.6 <0.3.0",
+                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -6206,85 +5643,78 @@
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.1",
-                  "from": "nopt@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
                 },
                 "fileset": {
                   "version": "0.1.5",
-                  "from": "fileset@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "3.2.11",
-                      "from": "glob@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
+                      "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 },
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "resolve": {
                   "version": "0.7.4",
-                  "from": "resolve@>=0.7.0 <0.8.0",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
                 },
                 "js-yaml": {
                   "version": "3.2.7",
-                  "from": "js-yaml@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.1",
-                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.2.0",
-                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.2",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.0.0",
-                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                     }
                   }
@@ -6293,32 +5723,27 @@
             },
             "estraverse": {
               "version": "1.5.1",
-              "from": "estraverse@>=1.5.0 <1.6.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
             },
             "escodegen": {
               "version": "1.1.0",
-              "from": "escodegen@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
               "dependencies": {
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                },
                 "esutils": {
                   "version": "1.0.0",
-                  "from": "esutils@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.30 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -6327,22 +5752,22 @@
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
@@ -6351,17 +5776,17 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
@@ -6370,148 +5795,133 @@
     },
     "karma-html2js-preprocessor": {
       "version": "0.1.0",
-      "from": "karma-html2js-preprocessor@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.5",
-      "from": "karma-jasmine@>=0.3.3 <0.4.0",
+      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
     },
     "karma-phantomjs-launcher": {
       "version": "0.1.4",
-      "from": "karma-phantomjs-launcher@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
       "dependencies": {
         "phantomjs": {
           "version": "1.9.15",
-          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "from": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
           "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.4",
-              "from": "adm-zip@0.4.4",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
             },
             "kew": {
               "version": "0.4.0",
-              "from": "kew@0.4.0",
+              "from": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
             },
             "npmconf": {
               "version": "2.0.9",
-              "from": "npmconf@2.0.9",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.8",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.3",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                     }
                   }
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "ini": {
                   "version": "1.3.3",
-                  "from": "ini@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.1",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.0",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.5",
-                  "from": "uid-number@0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
             "progress": {
               "version": "1.1.8",
-              "from": "progress@1.1.8",
+              "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
             "request": {
               "version": "2.42.0",
-              "from": "request@2.42.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -6519,154 +5929,154 @@
                 },
                 "caseless": {
                   "version": "0.6.0",
-                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "qs@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
+                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.2.11",
-                      "from": "mime@>=1.2.11 <1.3.0",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.4.0",
-                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 }
               }
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "request-progress@0.3.1",
+              "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
@@ -6677,122 +6087,122 @@
     },
     "mime": {
       "version": "1.3.4",
-      "from": "mime@>=1.2.11 <2.0.0",
+      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "minimist": {
-      "version": "1.1.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "minimist@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
     },
     "mustache": {
       "version": "1.1.0",
-      "from": "mustache@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
     },
     "ncp": {
       "version": "2.0.0",
-      "from": "ncp@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
     },
     "node-sass": {
       "version": "2.0.1",
-      "from": "node-sass@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "cross-spawn": {
           "version": "0.2.6",
-          "from": "cross-spawn@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "meow": {
           "version": "3.1.0",
-          "from": "meow@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.0.2",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.0",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                 }
               }
             },
             "indent-string": {
               "version": "1.2.1",
-              "from": "indent-string@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "1.1.2",
-                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.0",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                     }
                   }
@@ -6803,100 +6213,95 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "mocha": {
           "version": "2.1.0",
-          "from": "mocha@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
           "dependencies": {
             "commander": {
               "version": "2.3.0",
-              "from": "commander@2.3.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@2.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "diff": {
               "version": "1.0.8",
-              "from": "diff@1.0.8",
+              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "glob": {
               "version": "3.2.3",
-              "from": "glob@3.2.3",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "growl": {
               "version": "1.8.1",
-              "from": "growl@1.8.1",
+              "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
               "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
             },
             "jade": {
               "version": "0.26.3",
-              "from": "jade@0.26.3",
+              "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "commander@0.6.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.0",
-                  "from": "mkdirp@0.3.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                 }
               }
@@ -6905,111 +6310,96 @@
         },
         "nan": {
           "version": "1.6.2",
-          "from": "nan@>=1.6.2 <2.0.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
         },
         "npmconf": {
           "version": "2.1.1",
-          "from": "npmconf@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.8",
-              "from": "config-chain@>=1.1.8 <1.2.0",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.3",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                 }
               }
             },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "ini": {
               "version": "1.3.3",
-              "from": "ini@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
             },
             "nopt": {
               "version": "3.0.1",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.0",
-              "from": "osenv@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "uid-number@0.0.5",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "request": {
           "version": "2.53.0",
-          "from": "request@>=2.53.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -7017,203 +6407,198 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.11.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                 },
                 "boom": {
                   "version": "2.6.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             }
           }
         },
         "sass-graph": {
           "version": "1.0.3",
-          "from": "sass-graph@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
           "dependencies": {
             "commander": {
               "version": "2.6.0",
-              "from": "commander@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "glob": {
               "version": "4.4.1",
-              "from": "glob@>=4.3.4 <5.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -7222,12 +6607,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -7236,7 +6621,7 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
@@ -7245,44 +6630,44 @@
     },
     "nodemon": {
       "version": "1.3.7",
-      "from": "nodemon@>=1.3.6 <2.0.0",
+      "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.7.tgz",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.7.tgz",
       "dependencies": {
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "ps-tree": {
           "version": "0.0.3",
-          "from": "ps-tree@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
           "dependencies": {
             "event-stream": {
               "version": "0.5.3",
-              "from": "event-stream@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.2.8",
-                  "from": "optimist@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@>=0.0.1 <0.1.0",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -7293,17 +6678,17 @@
         },
         "touch": {
           "version": "0.0.3",
-          "from": "touch@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@>=1.0.10 <1.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
@@ -7312,136 +6697,126 @@
         },
         "update-notifier": {
           "version": "0.3.1",
-          "from": "update-notifier@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.1.tgz",
           "dependencies": {
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.5",
-                  "from": "graceful-fs@>=3.0.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "js-yaml": {
                   "version": "3.2.7",
-                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.1",
-                      "from": "argparse@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.1.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.2.0",
-                          "from": "lodash@>=3.2.0 <3.3.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.2",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.0.0",
-                      "from": "esprima@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.0.0",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                 },
                 "osenv": {
                   "version": "0.1.0",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "is-npm": {
               "version": "1.0.0",
-              "from": "is-npm@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
             },
             "latest-version": {
               "version": "1.0.0",
-              "from": "latest-version@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
               "dependencies": {
                 "package-json": {
                   "version": "1.1.0",
-                  "from": "package-json@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
                   "dependencies": {
                     "got": {
                       "version": "2.4.0",
-                      "from": "got@>=2.4.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
                       "dependencies": {
                         "duplexify": {
                           "version": "3.2.0",
-                          "from": "duplexify@>=3.2.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             }
@@ -7449,69 +6824,69 @@
                         },
                         "infinity-agent": {
                           "version": "1.0.2",
-                          "from": "infinity-agent@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
                         },
                         "is-stream": {
                           "version": "1.0.1",
-                          "from": "is-stream@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                         },
                         "object-assign": {
                           "version": "2.0.0",
-                          "from": "object-assign@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                         },
                         "prepend-http": {
                           "version": "1.0.1",
-                          "from": "prepend-http@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
                         },
                         "read-all-stream": {
                           "version": "1.0.2",
-                          "from": "read-all-stream@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
                         },
                         "statuses": {
                           "version": "1.2.1",
-                          "from": "statuses@>=1.2.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                         },
                         "timed-out": {
                           "version": "2.0.0",
-                          "from": "timed-out@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                         }
                       }
                     },
                     "registry-url": {
                       "version": "3.0.0",
-                      "from": "registry-url@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.0.tgz",
                       "dependencies": {
                         "rc": {
                           "version": "0.6.0",
-                          "from": "rc@>=0.6.0 <0.7.0",
+                          "from": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
                           "resolved": "https://registry.npmjs.org/rc/-/rc-0.6.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.10",
-                              "from": "minimist@>=0.0.7 <0.1.0",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                             },
                             "strip-json-comments": {
                               "version": "0.1.3",
-                              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             },
                             "ini": {
                               "version": "1.3.3",
-                              "from": "ini@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                             }
                           }
@@ -7524,22 +6899,22 @@
             },
             "semver-diff": {
               "version": "2.0.0",
-              "from": "semver-diff@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz"
             },
             "string-length": {
               "version": "1.0.0",
-              "from": "string-length@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -7552,101 +6927,91 @@
     },
     "opn": {
       "version": "1.0.1",
-      "from": "opn@1.0.1",
+      "from": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
     },
     "prompt": {
       "version": "0.2.14",
-      "from": "prompt@>=0.2.14 <0.3.0",
+      "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
       "dependencies": {
         "pkginfo": {
           "version": "0.3.0",
-          "from": "pkginfo@>=0.0.0 <1.0.0",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
         },
         "revalidator": {
           "version": "0.1.8",
-          "from": "revalidator@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
           "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
         },
         "utile": {
           "version": "0.2.1",
-          "from": "utile@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.9 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "deep-equal": {
               "version": "1.0.0",
-              "from": "deep-equal@*",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
             },
             "i": {
               "version": "0.3.2",
-              "from": "i@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/i/-/i-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "ncp": {
               "version": "0.4.2",
-              "from": "ncp@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         },
         "winston": {
           "version": "0.8.3",
-          "from": "winston@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-            },
-            "isstream": {
-              "version": "0.1.1",
-              "from": "isstream@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
@@ -7655,39 +7020,39 @@
     },
     "read": {
       "version": "1.0.5",
-      "from": "read@1.0.5",
+      "from": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
       "dependencies": {
         "mute-stream": {
           "version": "0.0.4",
-          "from": "mute-stream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
         }
       }
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
+      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "replacestream": {
       "version": "2.0.0",
-      "from": "replacestream@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz"
     },
     "requirejs": {
       "version": "2.1.16",
-      "from": "requirejs@>=2.1.16 <3.0.0",
+      "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz"
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@2.2.8",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "semver": {
       "version": "4.3.1",
-      "from": "semver@>=4.3.1 <5.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz"
     },
     "shelljs": {
@@ -7695,15 +7060,377 @@
       "from": "shelljs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
     },
+    "socket.io": {
+      "version": "1.3.5",
+      "from": "socket.io@1.3.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.5.tgz",
+      "dependencies": {
+        "engine.io": {
+          "version": "1.5.1",
+          "from": "engine.io@1.5.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.3",
+              "from": "debug@1.0.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "ws": {
+              "version": "0.5.0",
+              "from": "ws@0.5.0",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.4.3",
+                  "from": "nan@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+                },
+                "options": {
+                  "version": "0.0.6",
+                  "from": "options@>=0.0.5",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                },
+                "ultron": {
+                  "version": "1.0.1",
+                  "from": "ultron@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                }
+              }
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "2.2.4",
+          "from": "socket.io-parser@2.2.4",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "json3": {
+              "version": "3.2.6",
+              "from": "json3@3.2.6",
+              "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+            },
+            "component-emitter": {
+              "version": "1.1.2",
+              "from": "component-emitter@1.1.2",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+            },
+            "benchmark": {
+              "version": "1.0.0",
+              "from": "benchmark@1.0.0",
+              "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "1.3.5",
+          "from": "socket.io-client@1.3.5",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.5.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "engine.io-client": {
+              "version": "1.5.1",
+              "from": "engine.io-client@1.5.1",
+              "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
+              "dependencies": {
+                "has-cors": {
+                  "version": "1.0.3",
+                  "from": "has-cors@1.0.3",
+                  "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                  "dependencies": {
+                    "global": {
+                      "version": "2.0.1",
+                      "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                    }
+                  }
+                },
+                "ws": {
+                  "version": "0.4.31",
+                  "from": "ws@0.4.31",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "commander@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "nan": {
+                      "version": "0.3.2",
+                      "from": "nan@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.5.0",
+                  "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+                  "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                },
+                "debug": {
+                  "version": "1.0.4",
+                  "from": "debug@1.0.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "parseuri": {
+                  "version": "0.0.4",
+                  "from": "parseuri@0.0.4",
+                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "parsejson": {
+                  "version": "0.0.1",
+                  "from": "parsejson@0.0.1",
+                  "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
+                },
+                "parseqs": {
+                  "version": "0.0.2",
+                  "from": "parseqs@0.0.2",
+                  "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
+                },
+                "component-inherit": {
+                  "version": "0.0.3",
+                  "from": "component-inherit@0.0.3",
+                  "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                },
+                "better-assert": {
+                  "version": "1.0.2",
+                  "from": "better-assert@1.0.2",
+                  "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                  "dependencies": {
+                    "callsite": {
+                      "version": "1.0.0",
+                      "from": "callsite@1.0.0",
+                      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "component-bind": {
+              "version": "1.0.0",
+              "from": "component-bind@1.0.0",
+              "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+            },
+            "component-emitter": {
+              "version": "1.1.2",
+              "from": "component-emitter@1.1.2",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+            },
+            "object-component": {
+              "version": "0.0.3",
+              "from": "object-component@0.0.3",
+              "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+            },
+            "has-binary": {
+              "version": "0.1.6",
+              "from": "has-binary@0.1.6",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
+            },
+            "parseuri": {
+              "version": "0.0.2",
+              "from": "parseuri@0.0.2",
+              "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+              "dependencies": {
+                "better-assert": {
+                  "version": "1.0.2",
+                  "from": "better-assert@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                  "dependencies": {
+                    "callsite": {
+                      "version": "1.0.0",
+                      "from": "callsite@1.0.0",
+                      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "to-array": {
+              "version": "0.1.3",
+              "from": "to-array@0.1.3",
+              "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+            },
+            "backo2": {
+              "version": "1.0.2",
+              "from": "backo2@1.0.2",
+              "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+            }
+          }
+        },
+        "socket.io-adapter": {
+          "version": "0.3.1",
+          "from": "socket.io-adapter@0.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.2",
+              "from": "debug@1.0.2",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.2",
+              "from": "socket.io-parser@2.2.2",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "benchmark@1.0.0",
+                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                }
+              }
+            },
+            "object-keys": {
+              "version": "1.0.1",
+              "from": "object-keys@1.0.1",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+            }
+          }
+        },
+        "has-binary-data": {
+          "version": "0.1.3",
+          "from": "has-binary-data@0.1.3",
+          "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz"
+        },
+        "debug": {
+          "version": "2.1.0",
+          "from": "debug@2.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "1.2.1",
+          "from": "engine.io-parser@1.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+          "dependencies": {
+            "after": {
+              "version": "0.8.1",
+              "from": "after@0.8.1",
+              "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+            },
+            "arraybuffer.slice": {
+              "version": "0.0.6",
+              "from": "arraybuffer.slice@0.0.6",
+              "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+            },
+            "base64-arraybuffer": {
+              "version": "0.1.2",
+              "from": "base64-arraybuffer@0.1.2",
+              "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+            },
+            "blob": {
+              "version": "0.0.2",
+              "from": "blob@0.0.2",
+              "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+            },
+            "has-binary": {
+              "version": "0.1.5",
+              "from": "has-binary@0.1.5",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "utf8": {
+              "version": "2.0.0",
+              "from": "utf8@2.0.0",
+              "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "through": {
       "version": "2.3.6",
-      "from": "through@2.3.6",
+      "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
     },
     "uglify-js": {
-      "version": "2.4.16",
-      "from": "uglify-js@>=2.4.16 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
+      "version": "2.4.17",
+      "from": "uglify-js@>=2.4.17 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.17.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
@@ -7722,17 +7449,10 @@
             }
           }
         },
-        "optimist": {
-          "version": "0.3.7",
-          "from": "optimist@>=0.3.5 <0.4.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            }
-          }
+        "yargs": {
+          "version": "1.3.3",
+          "from": "yargs@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
@@ -7743,7 +7463,7 @@
     },
     "which": {
       "version": "1.0.9",
-      "from": "which@1.0.9",
+      "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,23 +30,23 @@
   },
   "dependencies": {
     "autoprefixer": "^5.0.0",
-    "aws-sdk": "^2.1.7",
+    "aws-sdk": "^2.1.18",
     "bower": "^1.3.12",
-    "browser-sync": "^2.2.1",
+    "browser-sync": "^2.4.0",
     "browserify": "^9.0.3",
     "chalk": "^1.0.0",
-    "chokidar": "^1.0.0-rc2",
+    "chokidar": "^1.0.0-rc4",
     "colors": "^1.0.3",
     "del": "^1.1.0",
     "es6-promise": "^2.0.1",
     "findup-sync": "^0.2.1",
-    "fs-extra": "^0.16.3",
+    "fs-extra": "^0.16.5",
     "gh-pages": "^0.2.0",
-    "glob-stream": "^4.0.0",
+    "glob-stream": "^5.0.0",
     "html-minifier": "^0.7.0",
     "jade": "^1.9.2",
     "jasmine-core": "^2.1.3",
-    "karma": "^0.12.31",
+    "karma": "^0.12.32",
     "karma-browserify": "^4.0.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "0.2.6",
@@ -54,7 +54,7 @@
     "karma-jasmine": "^0.3.3",
     "karma-phantomjs-launcher": "^0.1.4",
     "mime": "^1.2.11",
-    "minimist": "^1.1.0",
+    "minimist": "^1.1.1",
     "mustache": "^1.0.0",
     "ncp": "^2.0.0",
     "node-sass": "^2.0.1",
@@ -64,7 +64,7 @@
     "requirejs": "^2.1.16",
     "semver": "^4.3.1",
     "shelljs": "^0.3.0",
-    "uglify-js": "^2.4.16"
+    "uglify-js": "^2.4.17"
   },
   "repository": {
     "type": "git",
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "jasmine": "^2.1.1",
-    "jshint": "^2.6.0"
+    "jshint": "^2.6.3"
   },
   "bin": {
     "component": "./bin/component"

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
     "glob-stream": "^5.0.0",
     "html-minifier": "^0.7.0",
     "jade": "^1.9.2",
+    "jasmine": "^2.1.1",
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.32",
-    "karma-browserify": "^4.0.0",
+    "karma-browserify": "^4.1.2",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "0.2.6",
     "karma-html2js-preprocessor": "^0.1.0",
@@ -75,7 +76,6 @@
     "email": "peter.mouland@gmail.com"
   },
   "devDependencies": {
-    "jasmine": "^2.1.1",
     "jshint": "^2.6.3"
   },
   "bin": {

--- a/tasks/utils/fs.js
+++ b/tasks/utils/fs.js
@@ -118,7 +118,7 @@ function copy(srcGlob, destinationDirectory){
 }
 
 function glob(globArray){
-    var stream = gs.create(globArray);
+    var stream = gs.create(globArray, { allowEmpty: true });
     return new Promise(function(resolve, reject){
         var files = [];
         stream.on('data', function(fileObj){


### PR DESCRIPTION
this will lock the version numbers of dependencies to ensure people don't accidentally get an updated dependency this has not been tested